### PR TITLE
feat: bridge settlement lifecycle with multi-asset ledger routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New Make targets: `strict-auth-smoke-host`, `strict-auth-smoke-container`, and `production-readiness`
 - SDK docs for strict-auth smoke usage and Alpine/musl ctypes troubleshooting with glibc-container fallback
 - README and SDK README refresh covering badges, genesis testnet usage, observability endpoints, and Python SDK v2 feature surface
+- Bridge settlement lifecycle in `internal/bridge/bridge.go`, including burn → release flow, deterministic settlement records, and automatic refund-on-mint-failure handling
+- Multi-asset settlement routing with optional asset registry enforcement via the new `internal/token/registry.go`
+- Utility coin ledger hardening in `internal/token/ledger.go` with integer base-unit accounting, `burn` transactions, and state migration support from legacy float-backed snapshots
+- `bridge_transfer` settlement controls in Python SDK (`settle`, `settlement_minter`) and runtime API wiring in `internal/pyapi/api.go`
+- Environment-driven settlement configuration for multi-asset deployments (`MOHAWK_BRIDGE_SETTLEMENT_ASSETS`, per-asset ledger/minter overrides)
+- Compose rollout templates and operator guidance in `docker-compose.yml` for single-asset defaults and optional multi-asset settlement mode
+- Expanded automated coverage for settlement, multi-asset routing, env parsing/config loading, and ledger migration behavior (`test/bridge_hybrid_test.go`, `internal/pyapi/api_security_test.go`, `test/utility_coin_durability_test.go`)
 
 ### Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,18 @@ receipt = node.bridge_transfer(
     nonce=1,
     proof="proof-bytes",
 )
+
+settled = node.bridge_transfer(
+    source_chain="ethereum",
+    target_chain="polygon",
+    asset="MHC",
+    amount=2.0,
+    sender="0xabc",
+    receiver="0xdef",
+    nonce=2,
+    proof="proof-bytes",
+    settle=True,
+)
 ```
 
 See [sdk/python/README.md](sdk/python/README.md) for the complete API reference.
@@ -148,6 +160,34 @@ Stop the stack with:
 ```bash
 docker compose down
 ```
+
+### Multi-Asset Bridge Settlement Configuration
+
+Bridge settlement is optional and disabled by default. Set `settle=true` on `bridge_transfer(...)` requests to execute burn/release settlement after transfer verification.
+
+Use these runtime environment variables to enable registry-backed multi-asset settlement routing:
+
+```bash
+# Comma-separated symbols allowed for settlement
+export MOHAWK_BRIDGE_SETTLEMENT_ASSETS="MHC,USDX"
+
+# Default utility coin ledger (MHC)
+export MOHAWK_LEDGER_STATE_PATH="/var/lib/mohawk/mhc_state.json"
+export MOHAWK_LEDGER_AUDIT_PATH="/var/lib/mohawk/mhc_audit.jsonl"
+export MOHAWK_UTILITY_MINTER="protocol"
+
+# Per-asset ledger overrides (USDX)
+export MOHAWK_LEDGER_STATE_PATH_USDX="/var/lib/mohawk/usdx_state.json"
+export MOHAWK_LEDGER_AUDIT_PATH_USDX="/var/lib/mohawk/usdx_audit.jsonl"
+export MOHAWK_UTILITY_MINTER_USDX="protocol"
+```
+
+When configured, settlement enforces:
+
+* Asset must be present in `MOHAWK_BRIDGE_SETTLEMENT_ASSETS`.
+* Asset must have a configured settlement ledger.
+* Burn on sender occurs before destination mint/release.
+* Refund-to-sender executes if destination release fails.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     environment:
       - IPFS_API_ENDPOINT=http://ipfs:5001
       - MOHAWK_LIBP2P_PORT=4101
+      # Single-asset default mode: MHC settlement only (no extra env needed)
       - MOHAWK_LEDGER_STATE_PATH=/var/lib/mohawk/utility-ledger/state.json
       - MOHAWK_LEDGER_AUDIT_PATH=/var/lib/mohawk/utility-ledger/audit.jsonl
       - MOHAWK_API_AUTH_MODE=file-only
@@ -36,8 +37,16 @@ services:
       - MOHAWK_UTILITY_TRANSFER_ALLOWED_ROLES=user,operator,admin
       - MOHAWK_UTILITY_BACKUP_ALLOWED_ROLES=operator,admin
       - MOHAWK_UTILITY_RESTORE_ALLOWED_ROLES=admin
+      # Optional multi-asset mode: uncomment the lines below and provision matching volumes.
+      # Requests with settle=true must use an asset listed in MOHAWK_BRIDGE_SETTLEMENT_ASSETS.
+      # - MOHAWK_BRIDGE_SETTLEMENT_ASSETS=MHC,USDX
+      # - MOHAWK_LEDGER_STATE_PATH_USDX=/var/lib/mohawk/usdx-ledger/state.json
+      # - MOHAWK_LEDGER_AUDIT_PATH_USDX=/var/lib/mohawk/usdx-ledger/audit.jsonl
+      # - MOHAWK_UTILITY_MINTER_USDX=protocol
     volumes:
       - ./data/utility-ledger:/var/lib/mohawk/utility-ledger
+      # Optional: persistent storage for additional settlement assets
+      # - ./data/usdx-ledger:/var/lib/mohawk/usdx-ledger
       - ./secrets/mohawk_api_token:/run/secrets/mohawk_api_token:ro
     networks:
       - mohawk-net
@@ -118,6 +127,7 @@ services:
       - NODE_ID=node-1
       - IPFS_API_ENDPOINT=http://ipfs:5001
       - MOHAWK_LIBP2P_PORT=4001
+      # Single-asset default mode: MHC settlement only (no extra env needed)
       - MOHAWK_API_AUTH_MODE=file-only
       - MOHAWK_API_TOKEN_FILE=/run/secrets/mohawk_api_token
       - MOHAWK_API_ENFORCE_ROLES=true
@@ -129,7 +139,15 @@ services:
       - MOHAWK_UTILITY_TRANSFER_ALLOWED_ROLES=user,operator,admin
       - MOHAWK_UTILITY_BACKUP_ALLOWED_ROLES=operator,admin
       - MOHAWK_UTILITY_RESTORE_ALLOWED_ROLES=admin
+      # Optional multi-asset mode: uncomment the lines below and provision matching volumes.
+      # Requests with settle=true must use an asset listed in MOHAWK_BRIDGE_SETTLEMENT_ASSETS.
+      # - MOHAWK_BRIDGE_SETTLEMENT_ASSETS=MHC,USDX
+      # - MOHAWK_LEDGER_STATE_PATH_USDX=/var/lib/mohawk/usdx-ledger/state.json
+      # - MOHAWK_LEDGER_AUDIT_PATH_USDX=/var/lib/mohawk/usdx-ledger/audit.jsonl
+      # - MOHAWK_UTILITY_MINTER_USDX=protocol
     volumes:
+      # Optional: persistent storage for additional settlement assets
+      # - ./data/usdx-ledger:/var/lib/mohawk/usdx-ledger
       - ./secrets/mohawk_api_token:/run/secrets/mohawk_api_token:ro
     depends_on:
       - orchestrator
@@ -148,6 +166,7 @@ services:
       - NODE_ID=node-2
       - IPFS_API_ENDPOINT=http://ipfs:5001
       - MOHAWK_LIBP2P_PORT=4002
+      # Single-asset default mode: MHC settlement only (no extra env needed)
       - MOHAWK_API_AUTH_MODE=file-only
       - MOHAWK_API_TOKEN_FILE=/run/secrets/mohawk_api_token
       - MOHAWK_API_ENFORCE_ROLES=true
@@ -159,7 +178,15 @@ services:
       - MOHAWK_UTILITY_TRANSFER_ALLOWED_ROLES=user,operator,admin
       - MOHAWK_UTILITY_BACKUP_ALLOWED_ROLES=operator,admin
       - MOHAWK_UTILITY_RESTORE_ALLOWED_ROLES=admin
+      # Optional multi-asset mode: uncomment the lines below and provision matching volumes.
+      # Requests with settle=true must use an asset listed in MOHAWK_BRIDGE_SETTLEMENT_ASSETS.
+      # - MOHAWK_BRIDGE_SETTLEMENT_ASSETS=MHC,USDX
+      # - MOHAWK_LEDGER_STATE_PATH_USDX=/var/lib/mohawk/usdx-ledger/state.json
+      # - MOHAWK_LEDGER_AUDIT_PATH_USDX=/var/lib/mohawk/usdx-ledger/audit.jsonl
+      # - MOHAWK_UTILITY_MINTER_USDX=protocol
     volumes:
+      # Optional: persistent storage for additional settlement assets
+      # - ./data/usdx-ledger:/var/lib/mohawk/usdx-ledger
       - ./secrets/mohawk_api_token:/run/secrets/mohawk_api_token:ro
     depends_on:
       - orchestrator

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -6,7 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
+
+	"github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/internal/token"
 )
 
 // TransferRequest defines a chain-agnostic cross-chain transfer envelope.
@@ -38,11 +41,31 @@ type Receipt struct {
 	IssuedAtMS    int64  `json:"issued_at_ms"`
 }
 
+// SettlementRecord captures the bridge-to-ledger settlement lifecycle.
+type SettlementRecord struct {
+	Receipt      Receipt   `json:"receipt"`
+	Status       string    `json:"status"`
+	BurnTx       *token.Tx `json:"burn_tx,omitempty"`
+	MintTx       *token.Tx `json:"mint_tx,omitempty"`
+	RefundTx     *token.Tx `json:"refund_tx,omitempty"`
+	Failure      string    `json:"failure,omitempty"`
+	SettledAtMS  int64     `json:"settled_at_ms"`
+	SettlementID string    `json:"settlement_id"`
+}
+
 // Engine performs deterministic cross-chain envelope verification.
 type Engine struct {
 	BridgeID string
 	adapters map[string]Adapter
 	policies map[string]RoutePolicy
+
+	settlementMu       sync.RWMutex
+	settlementLedger   *token.Ledger
+	settlementMinter   string
+	settlementRegistry *token.Registry
+	settlementLedgers  map[string]*token.Ledger
+	settlementMinters  map[string]string
+	settlementRecords  map[string]SettlementRecord
 }
 
 // NewEngine creates a bridge engine with a stable ID.
@@ -51,12 +74,69 @@ func NewEngine(id string) *Engine {
 		id = "mohawk-bridge-v1"
 	}
 	engine := &Engine{
-		BridgeID: id,
-		adapters: map[string]Adapter{},
-		policies: map[string]RoutePolicy{},
+		BridgeID:          id,
+		adapters:          map[string]Adapter{},
+		policies:          map[string]RoutePolicy{},
+		settlementLedgers: map[string]*token.Ledger{},
+		settlementMinters: map[string]string{},
+		settlementRecords: map[string]SettlementRecord{},
 	}
 	engine.registerDefaults()
 	return engine
+}
+
+// EnableSettlement configures optional bridge settlement against a utility ledger.
+func (e *Engine) EnableSettlement(ledger *token.Ledger, settlementMinter string) {
+	e.settlementMu.Lock()
+	defer e.settlementMu.Unlock()
+	e.settlementLedger = ledger
+	if strings.TrimSpace(settlementMinter) == "" && ledger != nil {
+		settlementMinter = ledger.Minter()
+	}
+	e.settlementMinter = strings.TrimSpace(settlementMinter)
+	if ledger != nil {
+		symbol := normalizeAssetSymbol(ledger.Symbol())
+		e.settlementLedgers[symbol] = ledger
+		e.settlementMinters[symbol] = e.settlementMinter
+	}
+}
+
+// SetSettlementRegistry enforces that only registered assets can be settled.
+func (e *Engine) SetSettlementRegistry(registry *token.Registry) {
+	e.settlementMu.Lock()
+	defer e.settlementMu.Unlock()
+	e.settlementRegistry = registry
+}
+
+// RegisterSettlementLedger binds an asset symbol to a specific settlement ledger and minter.
+func (e *Engine) RegisterSettlementLedger(assetSymbol string, ledger *token.Ledger, settlementMinter string) error {
+	if ledger == nil {
+		return fmt.Errorf("settlement ledger is required")
+	}
+	symbol := normalizeAssetSymbol(assetSymbol)
+	if symbol == "" {
+		symbol = normalizeAssetSymbol(ledger.Symbol())
+	}
+	if symbol == "" {
+		return fmt.Errorf("asset symbol is required")
+	}
+	if strings.TrimSpace(settlementMinter) == "" {
+		settlementMinter = ledger.Minter()
+	}
+	e.settlementMu.Lock()
+	defer e.settlementMu.Unlock()
+	e.settlementLedgers[symbol] = ledger
+	e.settlementMinters[symbol] = strings.TrimSpace(settlementMinter)
+	return nil
+}
+
+// SettlementRecord returns a previously recorded settlement by receipt proof root.
+func (e *Engine) SettlementRecord(proofRoot string) (SettlementRecord, bool) {
+	proofRoot = strings.TrimSpace(proofRoot)
+	e.settlementMu.RLock()
+	defer e.settlementMu.RUnlock()
+	record, ok := e.settlementRecords[proofRoot]
+	return record, ok
 }
 
 func (e *Engine) registerDefaults() {
@@ -168,4 +248,132 @@ func (e *Engine) VerifyReceipt(req TransferRequest, receipt Receipt) error {
 		return fmt.Errorf("receipt proof root mismatch")
 	}
 	return nil
+}
+
+// SettleTransfer verifies and settles a transfer against the configured ledger.
+func (e *Engine) SettleTransfer(req TransferRequest) (SettlementRecord, error) {
+	receipt, err := e.VerifyTransfer(req)
+	if err != nil {
+		return SettlementRecord{}, err
+	}
+	return e.SettleVerifiedTransfer(req, receipt)
+}
+
+// SettleVerifiedTransfer settles a transfer that already has a verified receipt.
+func (e *Engine) SettleVerifiedTransfer(req TransferRequest, receipt Receipt) (SettlementRecord, error) {
+	if err := e.VerifyReceipt(req, receipt); err != nil {
+		return SettlementRecord{}, err
+	}
+
+	e.settlementMu.RLock()
+	if existing, ok := e.settlementRecords[receipt.ProofRoot]; ok {
+		e.settlementMu.RUnlock()
+		return existing, nil
+	}
+	e.settlementMu.RUnlock()
+
+	ledger, settlementMinter, err := e.resolveSettlementContext(req.Asset)
+	if err != nil {
+		return SettlementRecord{}, err
+	}
+
+	settlementID := fmt.Sprintf("%s:%s:%s:%d", normalizeChain(req.SourceChain), normalizeChain(req.TargetChain), strings.TrimSpace(req.Sender), req.Nonce)
+	burnTx, err := ledger.BurnWithControls(req.Sender, req.Amount, "bridge settlement burn", "settlement:"+settlementID+":burn", 0)
+	if err != nil {
+		record := SettlementRecord{
+			Receipt:      receipt,
+			Status:       "failed",
+			Failure:      err.Error(),
+			SettledAtMS:  time.Now().UnixMilli(),
+			SettlementID: settlementID,
+		}
+		e.setSettlementRecord(receipt.ProofRoot, record)
+		return record, err
+	}
+
+	mintTx, mintErr := ledger.MintWithControls(settlementMinter, req.Receiver, req.Amount, "bridge settlement release", "settlement:"+settlementID+":mint", 0)
+	if mintErr == nil {
+		record := SettlementRecord{
+			Receipt:      receipt,
+			Status:       "completed",
+			BurnTx:       &burnTx,
+			MintTx:       &mintTx,
+			SettledAtMS:  time.Now().UnixMilli(),
+			SettlementID: settlementID,
+		}
+		e.setSettlementRecord(receipt.ProofRoot, record)
+		return record, nil
+	}
+
+	refundActor := settlementMinter
+	if strings.TrimSpace(refundActor) == "" {
+		refundActor = ledger.Minter()
+	}
+	refundTx, refundErr := ledger.MintWithControls(refundActor, req.Sender, req.Amount, "bridge settlement refund", "settlement:"+settlementID+":refund", 0)
+	if refundErr != nil && !strings.EqualFold(refundActor, ledger.Minter()) {
+		refundTx, refundErr = ledger.MintWithControls(ledger.Minter(), req.Sender, req.Amount, "bridge settlement refund", "settlement:"+settlementID+":refund-fallback", 0)
+	}
+	status := "refunded"
+	failure := mintErr.Error()
+	var refundPtr *token.Tx
+	if refundErr != nil {
+		status = "failed"
+		failure = mintErr.Error() + "; refund failed: " + refundErr.Error()
+	} else {
+		refundPtr = &refundTx
+	}
+	record := SettlementRecord{
+		Receipt:      receipt,
+		Status:       status,
+		BurnTx:       &burnTx,
+		RefundTx:     refundPtr,
+		Failure:      failure,
+		SettledAtMS:  time.Now().UnixMilli(),
+		SettlementID: settlementID,
+	}
+	e.setSettlementRecord(receipt.ProofRoot, record)
+	return record, fmt.Errorf("settlement mint failed: %w", mintErr)
+}
+
+func (e *Engine) resolveSettlementContext(assetSymbol string) (*token.Ledger, string, error) {
+	symbol := normalizeAssetSymbol(assetSymbol)
+	e.settlementMu.RLock()
+	defer e.settlementMu.RUnlock()
+	if symbol == "" {
+		return nil, "", fmt.Errorf("asset is required for settlement")
+	}
+	if e.settlementRegistry != nil {
+		if _, ok := e.settlementRegistry.Get(symbol); !ok {
+			return nil, "", fmt.Errorf("asset %q is not registered for settlement", symbol)
+		}
+	}
+	if ledger, ok := e.settlementLedgers[symbol]; ok && ledger != nil {
+		minter := strings.TrimSpace(e.settlementMinters[symbol])
+		if minter == "" {
+			minter = ledger.Minter()
+		}
+		return ledger, minter, nil
+	}
+	if e.settlementLedger != nil && strings.EqualFold(symbol, normalizeAssetSymbol(e.settlementLedger.Symbol())) {
+		minter := strings.TrimSpace(e.settlementMinter)
+		if minter == "" {
+			minter = e.settlementLedger.Minter()
+		}
+		return e.settlementLedger, minter, nil
+	}
+	return nil, "", fmt.Errorf("asset %q has no configured settlement ledger", symbol)
+}
+
+func normalizeAssetSymbol(symbol string) string {
+	return strings.ToUpper(strings.TrimSpace(symbol))
+}
+
+func (e *Engine) setSettlementRecord(proofRoot string, record SettlementRecord) {
+	proofRoot = strings.TrimSpace(proofRoot)
+	e.settlementMu.Lock()
+	defer e.settlementMu.Unlock()
+	if e.settlementRecords == nil {
+		e.settlementRecords = map[string]SettlementRecord{}
+	}
+	e.settlementRecords[proofRoot] = record
 }

--- a/internal/pyapi/api.go
+++ b/internal/pyapi/api.go
@@ -346,6 +346,115 @@ func initUtilityCoinLedger() *token.Ledger {
 	return ledger
 }
 
+func parseBridgeSettlementAssets(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	unique := map[string]struct{}{}
+	assets := make([]string, 0)
+	for _, part := range strings.Split(raw, ",") {
+		symbol := strings.ToUpper(strings.TrimSpace(part))
+		if symbol == "" {
+			continue
+		}
+		if _, exists := unique[symbol]; exists {
+			continue
+		}
+		unique[symbol] = struct{}{}
+		assets = append(assets, symbol)
+	}
+	return assets
+}
+
+func symbolEnvSuffix(symbol string) string {
+	symbol = strings.ToUpper(strings.TrimSpace(symbol))
+	if symbol == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range symbol {
+		if (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			continue
+		}
+		b.WriteRune('_')
+	}
+	return b.String()
+}
+
+func loadBridgeSettlementConfig() (*token.Registry, map[string]*token.Ledger, map[string]string, error) {
+	assets := parseBridgeSettlementAssets(os.Getenv("MOHAWK_BRIDGE_SETTLEMENT_ASSETS"))
+	if len(assets) == 0 {
+		return nil, nil, nil, nil
+	}
+
+	registry := token.NewRegistry()
+	ledgers := map[string]*token.Ledger{}
+	minters := map[string]string{}
+	defaultSymbol := strings.ToUpper(strings.TrimSpace(utilityCoinLedger.Symbol()))
+
+	for _, symbol := range assets {
+		suffix := symbolEnvSuffix(symbol)
+		statePath := strings.TrimSpace(os.Getenv("MOHAWK_LEDGER_STATE_PATH_" + suffix))
+		auditPath := strings.TrimSpace(os.Getenv("MOHAWK_LEDGER_AUDIT_PATH_" + suffix))
+		minter := strings.TrimSpace(os.Getenv("MOHAWK_UTILITY_MINTER_" + suffix))
+
+		var ledger *token.Ledger
+		if minter == "" {
+			if symbol == defaultSymbol {
+				minter = utilityCoinLedger.Minter()
+			} else {
+				minter = "protocol"
+			}
+		}
+
+		if symbol == defaultSymbol && statePath == "" && auditPath == "" {
+			ledger = utilityCoinLedger
+		} else if statePath != "" && auditPath != "" {
+			persistentLedger, err := token.NewPersistentLedger(symbol, minter, statePath, auditPath)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("load settlement ledger %s: %w", symbol, err)
+			}
+			ledger = persistentLedger
+		} else {
+			ledger = token.NewLedger(symbol, minter)
+		}
+
+		ledgers[symbol] = ledger
+		minters[symbol] = minter
+		if err := registry.Register(ledger.Asset()); err != nil {
+			return nil, nil, nil, fmt.Errorf("register settlement asset %s: %w", symbol, err)
+		}
+	}
+
+	return registry, ledgers, minters, nil
+}
+
+func configureBridgeSettlement(engine *bridge.Engine, requestSettlementMinter string) error {
+	requestSettlementMinter = strings.TrimSpace(requestSettlementMinter)
+	engine.EnableSettlement(utilityCoinLedger, requestSettlementMinter)
+
+	registry, ledgers, minters, err := loadBridgeSettlementConfig()
+	if err != nil {
+		return err
+	}
+	if registry == nil {
+		return nil
+	}
+	engine.SetSettlementRegistry(registry)
+	defaultSymbol := strings.ToUpper(strings.TrimSpace(utilityCoinLedger.Symbol()))
+	for symbol, ledger := range ledgers {
+		minter := strings.TrimSpace(minters[symbol])
+		if symbol == defaultSymbol && requestSettlementMinter != "" {
+			minter = requestSettlementMinter
+		}
+		if err := engine.RegisterSettlementLedger(symbol, ledger, minter); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func loadAPIToken() string {
 	if token := strings.TrimSpace(os.Getenv("MOHAWK_API_TOKEN")); token != "" {
 		return token
@@ -686,6 +795,8 @@ func BridgeTransfer(payloadJSON *C.char) *C.char {
 		RoutePolicy        *bridge.RoutePolicy         `json:"route_policy,omitempty"`
 		PolicyManifestPath string                      `json:"policy_manifest_path,omitempty"`
 		PolicyManifest     *bridge.RoutePolicyManifest `json:"policy_manifest,omitempty"`
+		Settle             bool                        `json:"settle,omitempty"`
+		SettlementMinter   string                      `json:"settlement_minter,omitempty"`
 		AuthToken          string                      `json:"auth_token,omitempty"`
 		Authorization      string                      `json:"authorization,omitempty"`
 		APIToken           string                      `json:"api_token,omitempty"`
@@ -734,15 +845,33 @@ func BridgeTransfer(payloadJSON *C.char) *C.char {
 	if payload.RoutePolicy != nil {
 		engine.RegisterRoutePolicy(req.SourceChain, req.TargetChain, *payload.RoutePolicy)
 	}
+	if payload.Settle {
+		if err := configureBridgeSettlement(engine, payload.SettlementMinter); err != nil {
+			metrics.ObserveAcceleratorOp("cpu", "bridge_transfer", false)
+			return marshalResult(false, err.Error(), "")
+		}
+	}
 	receipt, err := engine.VerifyTransfer(req)
 	if err != nil {
 		metrics.ObserveAcceleratorOp("cpu", "bridge_transfer", false)
 		return marshalResult(false, err.Error(), "")
 	}
+	response := map[string]any{"receipt": receipt}
+	if payload.Settle {
+		settlement, settleErr := engine.SettleVerifiedTransfer(req, receipt)
+		if settleErr != nil {
+			metrics.ObserveAcceleratorOp("cpu", "bridge_transfer", false)
+			response["settlement"] = settlement
+			data, _ := json.Marshal(response)
+			return marshalResult(false, settleErr.Error(), string(data))
+		}
+		response["settlement"] = settlement
+	}
 	metrics.ObserveAcceleratorOp("cpu", "bridge_transfer", true)
-	data, _ := json.Marshal(map[string]any{
-		"receipt": receipt,
-	})
+	data, _ := json.Marshal(response)
+	if payload.Settle {
+		return marshalResult(true, "Cross-chain transfer verified and settled", string(data))
+	}
 	return marshalResult(true, "Cross-chain transfer verified", string(data))
 }
 

--- a/internal/pyapi/api_security_test.go
+++ b/internal/pyapi/api_security_test.go
@@ -136,3 +136,41 @@ func TestValidateAPIAccessFileOnlyModeRequiresFile(t *testing.T) {
 		t.Fatal("expected file-only mode to require token file")
 	}
 }
+
+func TestParseBridgeSettlementAssets(t *testing.T) {
+	assets := parseBridgeSettlementAssets(" mhc, USDX, mhc ,, usdx ")
+	if len(assets) != 2 {
+		t.Fatalf("expected 2 unique assets, got %d (%v)", len(assets), assets)
+	}
+	if assets[0] != "MHC" || assets[1] != "USDX" {
+		t.Fatalf("unexpected parsed assets: %v", assets)
+	}
+}
+
+func TestLoadBridgeSettlementConfigFromEnv(t *testing.T) {
+	t.Setenv("MOHAWK_BRIDGE_SETTLEMENT_ASSETS", "MHC,USDX")
+	t.Setenv("MOHAWK_UTILITY_MINTER_USDX", "mint-usdx")
+
+	registry, ledgers, minters, err := loadBridgeSettlementConfig()
+	if err != nil {
+		t.Fatalf("loadBridgeSettlementConfig failed: %v", err)
+	}
+	if registry == nil {
+		t.Fatal("expected settlement registry to be configured")
+	}
+	if _, ok := registry.Get("MHC"); !ok {
+		t.Fatal("expected MHC in settlement registry")
+	}
+	if _, ok := registry.Get("USDX"); !ok {
+		t.Fatal("expected USDX in settlement registry")
+	}
+	if len(ledgers) != 2 {
+		t.Fatalf("expected 2 settlement ledgers, got %d", len(ledgers))
+	}
+	if ledgers["MHC"] == nil || ledgers["USDX"] == nil {
+		t.Fatal("expected settlement ledgers for MHC and USDX")
+	}
+	if minters["USDX"] != "mint-usdx" {
+		t.Fatalf("unexpected USDX settlement minter: %q", minters["USDX"])
+	}
+}

--- a/internal/token/ledger.go
+++ b/internal/token/ledger.go
@@ -5,14 +5,16 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 )
 
-const currentSchemaVersion = 1
+const currentSchemaVersion = 2
 
 // TxType enumerates supported utility coin operations.
 type TxType string
@@ -20,27 +22,36 @@ type TxType string
 const (
 	TxMint     TxType = "mint"
 	TxTransfer TxType = "transfer"
+	TxBurn     TxType = "burn"
 )
 
 // Tx records a utility coin ledger event.
 type Tx struct {
-	Type      TxType    `json:"type"`
-	From      string    `json:"from,omitempty"`
-	To        string    `json:"to,omitempty"`
-	Amount    float64   `json:"amount"`
-	Memo      string    `json:"memo,omitempty"`
-	Timestamp time.Time `json:"timestamp"`
+	Type        TxType    `json:"type"`
+	From        string    `json:"from,omitempty"`
+	To          string    `json:"to,omitempty"`
+	Amount      float64   `json:"amount"`
+	AmountUnits int64     `json:"amount_units,omitempty"`
+	Memo        string    `json:"memo,omitempty"`
+	Timestamp   time.Time `json:"timestamp"`
+}
+
+// Asset defines the precision and supply constraints for a utility asset.
+type Asset struct {
+	Symbol         string `json:"symbol"`
+	Decimals       uint8  `json:"decimals"`
+	MaxSupplyUnits int64  `json:"max_supply_units,omitempty"`
 }
 
 // Ledger is a concurrency-safe in-memory utility coin ledger.
 type Ledger struct {
 	schemaVersion int
-	symbol        string
+	asset         Asset
 	minter        string
 	mu            sync.RWMutex
-	balances      map[string]float64
+	balances      map[string]int64
 	txns          []Tx
-	totalSupply   float64
+	totalSupply   int64
 	statePath     string
 	auditPath     string
 	auditPrev     string
@@ -49,40 +60,41 @@ type Ledger struct {
 }
 
 type persistentState struct {
-	SchemaVersion int                `json:"schema_version"`
-	Symbol        string             `json:"symbol"`
-	Minter        string             `json:"minter"`
-	Balances      map[string]float64 `json:"balances"`
-	Txns          []Tx               `json:"txns"`
-	TotalSupply   float64            `json:"total_supply"`
-	AuditPrev     string             `json:"audit_prev,omitempty"`
-	Nonces        map[string]uint64  `json:"nonces,omitempty"`
+	SchemaVersion    int                `json:"schema_version"`
+	Symbol           string             `json:"symbol,omitempty"`
+	Asset            Asset              `json:"asset,omitempty"`
+	Minter           string             `json:"minter"`
+	Balances         map[string]float64 `json:"balances,omitempty"`
+	BalancesUnits    map[string]int64   `json:"balances_units,omitempty"`
+	Txns             []Tx               `json:"txns"`
+	TotalSupply      float64            `json:"total_supply,omitempty"`
+	TotalSupplyUnits int64              `json:"total_supply_units,omitempty"`
+	AuditPrev        string             `json:"audit_prev,omitempty"`
+	Nonces           map[string]uint64  `json:"nonces,omitempty"`
 }
 
 type auditRecord struct {
-	Hash      string  `json:"hash"`
-	PrevHash  string  `json:"prev_hash,omitempty"`
-	Type      TxType  `json:"type"`
-	From      string  `json:"from,omitempty"`
-	To        string  `json:"to,omitempty"`
-	Amount    float64 `json:"amount"`
-	Memo      string  `json:"memo,omitempty"`
-	Timestamp string  `json:"timestamp"`
+	Hash        string  `json:"hash"`
+	PrevHash    string  `json:"prev_hash,omitempty"`
+	Type        TxType  `json:"type"`
+	From        string  `json:"from,omitempty"`
+	To          string  `json:"to,omitempty"`
+	Amount      float64 `json:"amount"`
+	AmountUnits int64   `json:"amount_units,omitempty"`
+	Memo        string  `json:"memo,omitempty"`
+	Timestamp   string  `json:"timestamp"`
 }
 
 // NewLedger creates a new utility coin ledger.
 func NewLedger(symbol string, minter string) *Ledger {
-	if strings.TrimSpace(symbol) == "" {
-		symbol = "MHC"
-	}
 	if strings.TrimSpace(minter) == "" {
 		minter = "protocol"
 	}
 	return &Ledger{
 		schemaVersion: currentSchemaVersion,
-		symbol:        strings.ToUpper(strings.TrimSpace(symbol)),
+		asset:         defaultAsset(symbol),
 		minter:        strings.TrimSpace(minter),
-		balances:      map[string]float64{},
+		balances:      map[string]int64{},
 		txns:          make([]Tx, 0, 64),
 		idempotency:   map[string]Tx{},
 		nonces:        map[string]uint64{},
@@ -107,7 +119,14 @@ func NewPersistentLedger(symbol string, minter string, statePath string, auditPa
 func (l *Ledger) Symbol() string {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
-	return l.symbol
+	return l.asset.Symbol
+}
+
+// Asset returns the configured utility asset metadata.
+func (l *Ledger) Asset() Asset {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.asset
 }
 
 // Minter returns the authorized minter identity.
@@ -127,6 +146,10 @@ func (l *Ledger) MintWithControls(actor string, to string, amount float64, memo 
 	actor = strings.TrimSpace(actor)
 	to = strings.TrimSpace(to)
 	idempotencyKey = strings.TrimSpace(idempotencyKey)
+	amountUnits, err := l.amountToUnits(amount)
+	if err != nil {
+		return Tx{}, err
+	}
 	if actor == "" {
 		actor = l.Minter()
 	}
@@ -135,9 +158,6 @@ func (l *Ledger) MintWithControls(actor string, to string, amount float64, memo 
 	}
 	if to == "" {
 		return Tx{}, fmt.Errorf("to account is required")
-	}
-	if amount <= 0 {
-		return Tx{}, fmt.Errorf("amount must be > 0")
 	}
 
 	l.mu.Lock()
@@ -154,14 +174,18 @@ func (l *Ledger) MintWithControls(actor string, to string, amount float64, memo 
 		}
 		l.nonces[actor] = nonce
 	}
-	l.balances[to] += amount
-	l.totalSupply += amount
+	if l.asset.MaxSupplyUnits > 0 && l.totalSupply > l.asset.MaxSupplyUnits-amountUnits {
+		return Tx{}, fmt.Errorf("mint exceeds max supply for %s", l.asset.Symbol)
+	}
+	l.balances[to] += amountUnits
+	l.totalSupply += amountUnits
 	tx := Tx{
-		Type:      TxMint,
-		To:        to,
-		Amount:    amount,
-		Memo:      memo,
-		Timestamp: time.Now().UTC(),
+		Type:        TxMint,
+		To:          to,
+		Amount:      l.unitsToAmount(amountUnits),
+		AmountUnits: amountUnits,
+		Memo:        memo,
+		Timestamp:   time.Now().UTC(),
 	}
 	l.txns = append(l.txns, tx)
 	if idempotencyKey != "" {
@@ -181,16 +205,22 @@ func (l *Ledger) Transfer(from string, to string, amount float64, memo string) (
 	return l.TransferWithControls(from, to, amount, memo, "", 0)
 }
 
+// Burn removes utility coins from an account.
+func (l *Ledger) Burn(from string, amount float64, memo string) (Tx, error) {
+	return l.BurnWithControls(from, amount, memo, "", 0)
+}
+
 // TransferWithControls transfers coins with optional idempotency and nonce replay controls.
 func (l *Ledger) TransferWithControls(from string, to string, amount float64, memo string, idempotencyKey string, nonce uint64) (Tx, error) {
 	from = strings.TrimSpace(from)
 	to = strings.TrimSpace(to)
 	idempotencyKey = strings.TrimSpace(idempotencyKey)
+	amountUnits, err := l.amountToUnits(amount)
+	if err != nil {
+		return Tx{}, err
+	}
 	if from == "" || to == "" {
 		return Tx{}, fmt.Errorf("from and to accounts are required")
-	}
-	if amount <= 0 {
-		return Tx{}, fmt.Errorf("amount must be > 0")
 	}
 
 	l.mu.Lock()
@@ -207,18 +237,71 @@ func (l *Ledger) TransferWithControls(from string, to string, amount float64, me
 		}
 		l.nonces[from] = nonce
 	}
-	if l.balances[from] < amount {
+	if l.balances[from] < amountUnits {
 		return Tx{}, fmt.Errorf("insufficient balance in %q", from)
 	}
-	l.balances[from] -= amount
-	l.balances[to] += amount
+	l.balances[from] -= amountUnits
+	l.balances[to] += amountUnits
 	tx := Tx{
-		Type:      TxTransfer,
-		From:      from,
-		To:        to,
-		Amount:    amount,
-		Memo:      memo,
-		Timestamp: time.Now().UTC(),
+		Type:        TxTransfer,
+		From:        from,
+		To:          to,
+		Amount:      l.unitsToAmount(amountUnits),
+		AmountUnits: amountUnits,
+		Memo:        memo,
+		Timestamp:   time.Now().UTC(),
+	}
+	l.txns = append(l.txns, tx)
+	if idempotencyKey != "" {
+		l.idempotency[idempotencyKey] = tx
+	}
+	if err := l.appendAuditLocked(tx); err != nil {
+		return Tx{}, err
+	}
+	if err := l.saveStateLocked(); err != nil {
+		return Tx{}, err
+	}
+	return tx, nil
+}
+
+// BurnWithControls burns coins with optional idempotency and nonce replay controls.
+func (l *Ledger) BurnWithControls(from string, amount float64, memo string, idempotencyKey string, nonce uint64) (Tx, error) {
+	from = strings.TrimSpace(from)
+	idempotencyKey = strings.TrimSpace(idempotencyKey)
+	amountUnits, err := l.amountToUnits(amount)
+	if err != nil {
+		return Tx{}, err
+	}
+	if from == "" {
+		return Tx{}, fmt.Errorf("from account is required")
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if idempotencyKey != "" {
+		if existing, ok := l.idempotency[idempotencyKey]; ok {
+			return existing, nil
+		}
+	}
+	if nonce > 0 {
+		last := l.nonces[from]
+		if nonce <= last {
+			return Tx{}, fmt.Errorf("replay detected for account %q: nonce %d <= %d", from, nonce, last)
+		}
+		l.nonces[from] = nonce
+	}
+	if l.balances[from] < amountUnits {
+		return Tx{}, fmt.Errorf("insufficient balance in %q", from)
+	}
+	l.balances[from] -= amountUnits
+	l.totalSupply -= amountUnits
+	tx := Tx{
+		Type:        TxBurn,
+		From:        from,
+		Amount:      l.unitsToAmount(amountUnits),
+		AmountUnits: amountUnits,
+		Memo:        memo,
+		Timestamp:   time.Now().UTC(),
 	}
 	l.txns = append(l.txns, tx)
 	if idempotencyKey != "" {
@@ -238,6 +321,14 @@ func (l *Ledger) Balance(account string) float64 {
 	account = strings.TrimSpace(account)
 	l.mu.RLock()
 	defer l.mu.RUnlock()
+	return l.unitsToAmount(l.balances[account])
+}
+
+// BalanceUnits returns the raw base-unit balance for an account.
+func (l *Ledger) BalanceUnits(account string) int64 {
+	account = strings.TrimSpace(account)
+	l.mu.RLock()
+	defer l.mu.RUnlock()
 	return l.balances[account]
 }
 
@@ -246,31 +337,85 @@ func (l *Ledger) Snapshot() map[string]any {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 	balances := make(map[string]float64, len(l.balances))
-	for account, amount := range l.balances {
-		balances[account] = amount
+	balancesUnits := make(map[string]int64, len(l.balances))
+	for account, amountUnits := range l.balances {
+		balances[account] = l.unitsToAmount(amountUnits)
+		balancesUnits[account] = amountUnits
 	}
 	return map[string]any{
-		"schema_version": l.schemaVersion,
-		"symbol":         l.symbol,
-		"minter":         l.minter,
-		"total_supply":   l.totalSupply,
-		"balances":       balances,
-		"tx_count":       len(l.txns),
-		"audit_prev":     l.auditPrev,
+		"schema_version":     l.schemaVersion,
+		"symbol":             l.asset.Symbol,
+		"asset":              l.asset,
+		"decimals":           l.asset.Decimals,
+		"unit_scale":         unitScale(l.asset.Decimals),
+		"minter":             l.minter,
+		"total_supply":       l.unitsToAmount(l.totalSupply),
+		"total_supply_units": l.totalSupply,
+		"balances":           balances,
+		"balances_units":     balancesUnits,
+		"tx_count":           len(l.txns),
+		"audit_prev":         l.auditPrev,
 	}
+}
+
+// SetAssetPolicy updates the ledger asset policy.
+func (l *Ledger) SetAssetPolicy(asset Asset) error {
+	normalized := normalizeAsset(asset)
+	if normalized.Symbol == "" {
+		return fmt.Errorf("asset symbol is required")
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.totalSupply > 0 && !strings.EqualFold(normalized.Symbol, l.asset.Symbol) {
+		return fmt.Errorf("cannot change asset symbol with non-zero supply")
+	}
+	if normalized.MaxSupplyUnits > 0 && normalized.MaxSupplyUnits < l.totalSupply {
+		return fmt.Errorf("max supply below current total supply")
+	}
+	l.asset = normalized
+	return l.saveStateLocked()
+}
+
+// AmountToUnits converts a decimal amount into integer base units.
+func (l *Ledger) AmountToUnits(amount float64) (int64, error) {
+	l.mu.RLock()
+	asset := l.asset
+	l.mu.RUnlock()
+	return amountToUnitsForAsset(amount, asset)
+}
+
+// UnitsToAmount converts integer base units into a decimal amount.
+func (l *Ledger) UnitsToAmount(amountUnits int64) float64 {
+	l.mu.RLock()
+	asset := l.asset
+	l.mu.RUnlock()
+	return unitsToAmountForAsset(amountUnits, asset)
 }
 
 // Backup copies the current state file to the provided path.
 func (l *Ledger) Backup(backupPath string) error {
 	l.mu.RLock()
-	statePath := l.statePath
-	l.mu.RUnlock()
-	if strings.TrimSpace(statePath) == "" {
+	if strings.TrimSpace(l.statePath) == "" {
+		l.mu.RUnlock()
 		return fmt.Errorf("backup unavailable: persistent state is not configured")
 	}
-	data, err := os.ReadFile(statePath)
+	state := persistentState{
+		SchemaVersion:    currentSchemaVersion,
+		Symbol:           l.asset.Symbol,
+		Asset:            l.asset,
+		Minter:           l.minter,
+		Balances:         l.amountBalancesLocked(),
+		BalancesUnits:    l.copyBalancesUnitsLocked(),
+		Txns:             l.txns,
+		TotalSupply:      l.unitsToAmount(l.totalSupply),
+		TotalSupplyUnits: l.totalSupply,
+		AuditPrev:        l.auditPrev,
+		Nonces:           l.nonces,
+	}
+	l.mu.RUnlock()
+	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
-		return fmt.Errorf("read state for backup: %w", err)
+		return fmt.Errorf("marshal backup state: %w", err)
 	}
 	if err := os.MkdirAll(filepath.Dir(backupPath), 0o755); err != nil {
 		return fmt.Errorf("ensure backup dir: %w", err)
@@ -320,9 +465,13 @@ func (l *Ledger) loadState() error {
 	if err := json.Unmarshal(raw, &state); err != nil {
 		return fmt.Errorf("parse state: %w", err)
 	}
+	needsMigration := state.SchemaVersion != currentSchemaVersion || state.BalancesUnits == nil || (state.TotalSupplyUnits == 0 && state.TotalSupply > 0) || strings.TrimSpace(state.Asset.Symbol) == ""
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.applyStateLocked(state)
+	if needsMigration {
+		return l.saveStateLocked()
+	}
 	return nil
 }
 
@@ -331,18 +480,41 @@ func (l *Ledger) applyStateLocked(state persistentState) {
 		state.SchemaVersion = 1
 	}
 	l.schemaVersion = currentSchemaVersion
-	if strings.TrimSpace(state.Symbol) != "" {
-		l.symbol = strings.ToUpper(strings.TrimSpace(state.Symbol))
+	l.asset = normalizeAsset(state.Asset)
+	if l.asset.Symbol == "" {
+		l.asset = defaultAsset(state.Symbol)
 	}
 	if strings.TrimSpace(state.Minter) != "" {
 		l.minter = strings.TrimSpace(state.Minter)
 	}
-	if state.Balances == nil {
-		state.Balances = map[string]float64{}
+	if state.BalancesUnits == nil {
+		state.BalancesUnits = make(map[string]int64, len(state.Balances))
+		for account, amount := range state.Balances {
+			amountUnits, err := amountToUnitsForAsset(amount, l.asset)
+			if err != nil {
+				continue
+			}
+			state.BalancesUnits[account] = amountUnits
+		}
 	}
-	l.balances = state.Balances
+	for index := range state.Txns {
+		if state.Txns[index].AmountUnits == 0 && state.Txns[index].Amount > 0 {
+			amountUnits, err := amountToUnitsForAsset(state.Txns[index].Amount, l.asset)
+			if err == nil {
+				state.Txns[index].AmountUnits = amountUnits
+			}
+		}
+		state.Txns[index].Amount = unitsToAmountForAsset(state.Txns[index].AmountUnits, l.asset)
+	}
+	l.balances = state.BalancesUnits
 	l.txns = state.Txns
-	l.totalSupply = state.TotalSupply
+	if state.TotalSupplyUnits == 0 && state.TotalSupply > 0 {
+		amountUnits, err := amountToUnitsForAsset(state.TotalSupply, l.asset)
+		if err == nil {
+			state.TotalSupplyUnits = amountUnits
+		}
+	}
+	l.totalSupply = state.TotalSupplyUnits
 	l.auditPrev = strings.TrimSpace(state.AuditPrev)
 	if state.Nonces == nil {
 		state.Nonces = map[string]uint64{}
@@ -356,14 +528,17 @@ func (l *Ledger) saveStateLocked() error {
 		return nil
 	}
 	state := persistentState{
-		SchemaVersion: currentSchemaVersion,
-		Symbol:        l.symbol,
-		Minter:        l.minter,
-		Balances:      l.balances,
-		Txns:          l.txns,
-		TotalSupply:   l.totalSupply,
-		AuditPrev:     l.auditPrev,
-		Nonces:        l.nonces,
+		SchemaVersion:    currentSchemaVersion,
+		Symbol:           l.asset.Symbol,
+		Asset:            l.asset,
+		Minter:           l.minter,
+		Balances:         l.amountBalancesLocked(),
+		BalancesUnits:    l.copyBalancesUnitsLocked(),
+		Txns:             l.txns,
+		TotalSupply:      l.unitsToAmount(l.totalSupply),
+		TotalSupplyUnits: l.totalSupply,
+		AuditPrev:        l.auditPrev,
+		Nonces:           l.nonces,
 	}
 	raw, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
@@ -383,14 +558,15 @@ func (l *Ledger) appendAuditLocked(tx Tx) error {
 	sum := sha256.Sum256(append([]byte(l.auditPrev), canonical...))
 	hash := hex.EncodeToString(sum[:])
 	rec := auditRecord{
-		Hash:      hash,
-		PrevHash:  l.auditPrev,
-		Type:      tx.Type,
-		From:      tx.From,
-		To:        tx.To,
-		Amount:    tx.Amount,
-		Memo:      tx.Memo,
-		Timestamp: tx.Timestamp.UTC().Format(time.RFC3339Nano),
+		Hash:        hash,
+		PrevHash:    l.auditPrev,
+		Type:        tx.Type,
+		From:        tx.From,
+		To:          tx.To,
+		Amount:      tx.Amount,
+		AmountUnits: tx.AmountUnits,
+		Memo:        tx.Memo,
+		Timestamp:   tx.Timestamp.UTC().Format(time.RFC3339Nano),
 	}
 	line, err := json.Marshal(rec)
 	if err != nil {
@@ -406,4 +582,86 @@ func (l *Ledger) appendAuditLocked(tx Tx) error {
 	}
 	l.auditPrev = hash
 	return nil
+}
+
+func (l *Ledger) amountToUnits(amount float64) (int64, error) {
+	return amountToUnitsForAsset(amount, l.asset)
+}
+
+func (l *Ledger) unitsToAmount(amountUnits int64) float64 {
+	return unitsToAmountForAsset(amountUnits, l.asset)
+}
+
+func (l *Ledger) amountBalancesLocked() map[string]float64 {
+	balances := make(map[string]float64, len(l.balances))
+	for account, amountUnits := range l.balances {
+		balances[account] = l.unitsToAmount(amountUnits)
+	}
+	return balances
+}
+
+func (l *Ledger) copyBalancesUnitsLocked() map[string]int64 {
+	balances := make(map[string]int64, len(l.balances))
+	for account, amountUnits := range l.balances {
+		balances[account] = amountUnits
+	}
+	return balances
+}
+
+func defaultAsset(symbol string) Asset {
+	asset := normalizeAsset(Asset{Symbol: symbol, Decimals: 6})
+	if asset.Symbol == "" {
+		asset.Symbol = "MHC"
+	}
+	return asset
+}
+
+func normalizeAsset(asset Asset) Asset {
+	asset.Symbol = strings.ToUpper(strings.TrimSpace(asset.Symbol))
+	if asset.Decimals == 0 {
+		asset.Decimals = 6
+	}
+	return asset
+}
+
+func amountToUnitsForAsset(amount float64, asset Asset) (int64, error) {
+	asset = normalizeAsset(asset)
+	if math.IsNaN(amount) || math.IsInf(amount, 0) {
+		return 0, fmt.Errorf("amount must be finite")
+	}
+	if amount <= 0 {
+		return 0, fmt.Errorf("amount must be > 0")
+	}
+	formatted := strconv.FormatFloat(amount, 'f', int(asset.Decimals), 64)
+	parts := strings.SplitN(formatted, ".", 2)
+	whole := parts[0]
+	fraction := ""
+	if len(parts) == 2 {
+		fraction = parts[1]
+	}
+	if int(asset.Decimals) > 0 {
+		fraction = fraction + strings.Repeat("0", int(asset.Decimals)-len(fraction))
+	}
+	combined := whole + fraction
+	amountUnits, err := strconv.ParseInt(combined, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("amount exceeds supported range")
+	}
+	if amountUnits <= 0 {
+		return 0, fmt.Errorf("amount must be > 0")
+	}
+	return amountUnits, nil
+}
+
+func unitsToAmountForAsset(amountUnits int64, asset Asset) float64 {
+	asset = normalizeAsset(asset)
+	return float64(amountUnits) / float64(unitScale(asset.Decimals))
+}
+
+func unitScale(decimals uint8) int64 {
+	scale := int64(1)
+	for range decimals {
+		scale *= 10
+	}
+	return scale
 }

--- a/internal/token/registry.go
+++ b/internal/token/registry.go
@@ -1,0 +1,61 @@
+package token
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Registry stores asset definitions by symbol.
+type Registry struct {
+	mu     sync.RWMutex
+	assets map[string]Asset
+}
+
+// NewRegistry creates an empty asset registry.
+func NewRegistry() *Registry {
+	return &Registry{assets: map[string]Asset{}}
+}
+
+// NewRegistryWithDefaults creates a registry seeded with default utility assets.
+func NewRegistryWithDefaults() *Registry {
+	r := NewRegistry()
+	_ = r.Register(defaultAsset("MHC"))
+	return r
+}
+
+// Register adds or replaces an asset definition.
+func (r *Registry) Register(asset Asset) error {
+	normalized := normalizeAsset(asset)
+	if normalized.Symbol == "" {
+		return fmt.Errorf("asset symbol is required")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.assets[normalized.Symbol] = normalized
+	return nil
+}
+
+// Get returns an asset by symbol.
+func (r *Registry) Get(symbol string) (Asset, bool) {
+	normalized := strings.ToUpper(strings.TrimSpace(symbol))
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	asset, ok := r.assets[normalized]
+	return asset, ok
+}
+
+// List returns all registered assets sorted by symbol.
+func (r *Registry) List() []Asset {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	items := make([]Asset, 0, len(r.assets))
+	for _, asset := range r.assets {
+		items = append(items, asset)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Symbol < items[j].Symbol
+	})
+	return items
+}

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -151,6 +151,19 @@ receipt = node.bridge_transfer(
 )
 print(receipt)
 
+settled = node.bridge_transfer(
+    source_chain="ethereum",
+    target_chain="polygon",
+    asset="MHC",
+    amount=2.0,
+    sender="0xabc",
+    receiver="0xdef",
+    nonce=2,
+    proof="proof-bytes",
+    settle=True,
+)
+print(settled)
+
 minted = node.mint_utility_coin(
     to="edge-alice",
     amount=100.0,
@@ -212,7 +225,7 @@ Main class for interacting with the MOHAWK runtime.
 - **`device_info()`**: Enumerate available CPU/GPU/NPU backends
 - **`compress_gradients(gradients, format='fp16'|'int8')`**: Quantize gradients for transport
 - **`stream_aggregate(gradient_stream, format='fp16'|'int8')`**: Buffer + compress gradient stream
-- **`bridge_transfer(..., auth_token=None, role=None)`**: Cross-chain transfer envelope verification + receipt generation
+- **`bridge_transfer(..., settle=False, settlement_minter=None, auth_token=None, role=None)`**: Cross-chain transfer verification with optional settlement execution
 - **`mint_utility_coin(to, amount, actor='protocol', auth_token=None, idempotency_key=None, nonce=None, role=None)`**: Mint utility coin balances with optional API auth + replay controls
 - **`transfer_utility_coin(from_account, to_account, amount, auth_token=None, idempotency_key=None, nonce=None, role=None)`**: Transfer utility coin with optional API auth + replay controls
 - **`utility_coin_balance(account)`**: Retrieve utility coin balance
@@ -224,6 +237,13 @@ Bridge policy fallback:
 
 - If no `route_policy`, `policy_manifest`, or `policy_manifest_path` is supplied to `bridge_transfer`, the runtime automatically attempts to load a default manifest from `bridge-policies.json`.
 - Override the default path with environment variable `MOHAWK_BRIDGE_POLICY_MANIFEST`.
+
+Bridge settlement runtime controls:
+
+- Set `settle=True` on `bridge_transfer(...)` to execute settlement after receipt verification.
+- Set `MOHAWK_BRIDGE_SETTLEMENT_ASSETS` (for example `MHC,USDX`) to enforce a settlement asset registry.
+- Use `MOHAWK_LEDGER_STATE_PATH_<SYMBOL>` and `MOHAWK_LEDGER_AUDIT_PATH_<SYMBOL>` for per-asset persistent ledgers.
+- Use `MOHAWK_UTILITY_MINTER_<SYMBOL>` for per-asset settlement mint actors.
 
 Utility coin hardening runtime controls:
 

--- a/sdk/python/mohawk/client.py
+++ b/sdk/python/mohawk/client.py
@@ -245,6 +245,8 @@ class MohawkNode:
         route_policy: Optional[Mapping[str, Any]] = None,
         policy_manifest_path: Optional[str] = None,
         policy_manifest: Optional[Mapping[str, Any]] = None,
+        settle: bool = False,
+        settlement_minter: Optional[str] = None,
         finality_depth: int = 0,
         auth_token: Optional[str] = None,
         role: Optional[str] = None,
@@ -268,6 +270,10 @@ class MohawkNode:
             payload["policy_manifest_path"] = policy_manifest_path
         if policy_manifest is not None:
             payload["policy_manifest"] = dict(policy_manifest)
+        if settle:
+            payload["settle"] = True
+        if settlement_minter is not None:
+            payload["settlement_minter"] = settlement_minter
         if auth_token is not None:
             payload["auth_token"] = auth_token
         if role is not None:

--- a/test/bridge_hybrid_test.go
+++ b/test/bridge_hybrid_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/internal/bridge"
 	"github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/internal/hybrid"
+	"github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/internal/token"
 )
 
 func TestBridgeTransfer(t *testing.T) {
@@ -208,6 +209,154 @@ func TestBridgeRoutePolicy(t *testing.T) {
 	req.Asset = "DAI"
 	if _, err := engine.VerifyTransfer(req); err == nil {
 		t.Fatal("expected policy asset rejection")
+	}
+}
+
+func TestBridgeSettlementSuccess(t *testing.T) {
+	ledger := token.NewLedger("MHC", "protocol")
+	if _, err := ledger.Mint("protocol", "0xaaa", 10, "seed"); err != nil {
+		t.Fatalf("seed mint failed: %v", err)
+	}
+
+	engine := bridge.NewEngine("test-bridge")
+	engine.EnableSettlement(ledger, "protocol")
+	record, err := engine.SettleTransfer(bridge.TransferRequest{
+		SourceChain: "ethereum",
+		TargetChain: "polygon",
+		Asset:       "MHC",
+		Amount:      3,
+		Sender:      "0xaaa",
+		Receiver:    "0xbbb",
+		Nonce:       11,
+		Proof:       "proof-bytes",
+	})
+	if err != nil {
+		t.Fatalf("settlement failed: %v", err)
+	}
+	if record.Status != "completed" {
+		t.Fatalf("unexpected settlement status: %s", record.Status)
+	}
+	if got := ledger.Balance("0xaaa"); got != 7 {
+		t.Fatalf("unexpected sender balance after settlement: %.4f", got)
+	}
+	if got := ledger.Balance("0xbbb"); got != 3 {
+		t.Fatalf("unexpected receiver balance after settlement: %.4f", got)
+	}
+	if record.BurnTx == nil || record.MintTx == nil {
+		t.Fatal("expected burn and mint txs in settlement record")
+	}
+}
+
+func TestBridgeSettlementRefundFallback(t *testing.T) {
+	ledger := token.NewLedger("MHC", "protocol")
+	if _, err := ledger.Mint("protocol", "0xabc", 9, "seed"); err != nil {
+		t.Fatalf("seed mint failed: %v", err)
+	}
+	if err := ledger.SetAssetPolicy(token.Asset{Symbol: "MHC", Decimals: 6, MaxSupplyUnits: 9000000}); err != nil {
+		t.Fatalf("set asset policy failed: %v", err)
+	}
+
+	engine := bridge.NewEngine("test-bridge")
+	engine.EnableSettlement(ledger, "attacker")
+	record, err := engine.SettleTransfer(bridge.TransferRequest{
+		SourceChain: "ethereum",
+		TargetChain: "polygon",
+		Asset:       "MHC",
+		Amount:      2,
+		Sender:      "0xabc",
+		Receiver:    "0xdef",
+		Nonce:       12,
+		Proof:       "proof-bytes",
+	})
+	if err == nil {
+		t.Fatal("expected settlement to fail when custom minter is unauthorized")
+	}
+	if record.Status != "refunded" {
+		t.Fatalf("expected refunded status, got %s", record.Status)
+	}
+	if record.RefundTx == nil {
+		t.Fatal("expected refund tx in settlement record")
+	}
+	if got := ledger.Balance("0xabc"); got != 9 {
+		t.Fatalf("unexpected sender balance after refund: %.4f", got)
+	}
+	if got := ledger.Balance("0xdef"); got != 0 {
+		t.Fatalf("unexpected receiver balance after failed settlement: %.4f", got)
+	}
+}
+
+func TestBridgeSettlementMultiAssetRouting(t *testing.T) {
+	mhcLedger := token.NewLedger("MHC", "protocol")
+	usdxLedger := token.NewLedger("USDX", "protocol")
+	if _, err := usdxLedger.Mint("protocol", "cosmos1alice", 8, "seed"); err != nil {
+		t.Fatalf("seed mint failed: %v", err)
+	}
+
+	registry := token.NewRegistryWithDefaults()
+	if err := registry.Register(token.Asset{Symbol: "USDX", Decimals: 6}); err != nil {
+		t.Fatalf("register usdx asset failed: %v", err)
+	}
+
+	engine := bridge.NewEngine("test-bridge")
+	engine.SetSettlementRegistry(registry)
+	if err := engine.RegisterSettlementLedger("MHC", mhcLedger, "protocol"); err != nil {
+		t.Fatalf("register MHC ledger failed: %v", err)
+	}
+	if err := engine.RegisterSettlementLedger("USDX", usdxLedger, "protocol"); err != nil {
+		t.Fatalf("register USDX ledger failed: %v", err)
+	}
+
+	record, err := engine.SettleTransfer(bridge.TransferRequest{
+		SourceChain: "cosmos",
+		TargetChain: "ethereum",
+		Asset:       "USDX",
+		Amount:      3,
+		Sender:      "cosmos1alice",
+		Receiver:    "0xreceiver",
+		Nonce:       21,
+		Proof:       "proof-bytes",
+	})
+	if err != nil {
+		t.Fatalf("multi-asset settlement failed: %v", err)
+	}
+	if record.Status != "completed" {
+		t.Fatalf("unexpected settlement status: %s", record.Status)
+	}
+	if got := usdxLedger.Balance("cosmos1alice"); got != 5 {
+		t.Fatalf("unexpected usdx sender balance: %.4f", got)
+	}
+	if got := usdxLedger.Balance("0xreceiver"); got != 3 {
+		t.Fatalf("unexpected usdx receiver balance: %.4f", got)
+	}
+	if got := mhcLedger.Balance("0xreceiver"); got != 0 {
+		t.Fatalf("unexpected mhc receiver balance: %.4f", got)
+	}
+}
+
+func TestBridgeSettlementRegistryRejectsUnknownAsset(t *testing.T) {
+	ledger := token.NewLedger("MHC", "protocol")
+	if _, err := ledger.Mint("protocol", "0xsender", 4, "seed"); err != nil {
+		t.Fatalf("seed mint failed: %v", err)
+	}
+
+	registry := token.NewRegistryWithDefaults()
+	engine := bridge.NewEngine("test-bridge")
+	engine.SetSettlementRegistry(registry)
+	if err := engine.RegisterSettlementLedger("MHC", ledger, "protocol"); err != nil {
+		t.Fatalf("register settlement ledger failed: %v", err)
+	}
+
+	if _, err := engine.SettleTransfer(bridge.TransferRequest{
+		SourceChain: "ethereum",
+		TargetChain: "polygon",
+		Asset:       "USDX",
+		Amount:      1,
+		Sender:      "0xsender",
+		Receiver:    "0xreceiver",
+		Nonce:       22,
+		Proof:       "proof-bytes",
+	}); err == nil {
+		t.Fatal("expected unknown asset settlement to fail")
 	}
 }
 

--- a/test/utility_coin_durability_test.go
+++ b/test/utility_coin_durability_test.go
@@ -1,6 +1,8 @@
 package test
 
 import (
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -77,5 +79,133 @@ func TestUtilityCoinIdempotencyAndNonceReplay(t *testing.T) {
 	}
 	if _, err := ledger.TransferWithControls("edge-a", "edge-b", 2, "replay", "tx-2", 2); err == nil {
 		t.Fatal("expected nonce replay to fail")
+	}
+}
+
+func TestUtilityCoinBaseUnitSnapshot(t *testing.T) {
+	ledger := token.NewLedger("MHC", "protocol")
+
+	if _, err := ledger.Mint("protocol", "edge-a", 1.25, "seed"); err != nil {
+		t.Fatalf("mint failed: %v", err)
+	}
+	if got := ledger.BalanceUnits("edge-a"); got != 1250000 {
+		t.Fatalf("unexpected base-unit balance: %d", got)
+	}
+
+	snapshot := ledger.Snapshot()
+	if got, ok := snapshot["total_supply_units"].(int64); !ok || got != 1250000 {
+		t.Fatalf("unexpected total_supply_units snapshot value: %#v", snapshot["total_supply_units"])
+	}
+	balancesUnits, ok := snapshot["balances_units"].(map[string]int64)
+	if !ok {
+		t.Fatalf("unexpected balances_units snapshot type: %T", snapshot["balances_units"])
+	}
+	if got := balancesUnits["edge-a"]; got != 1250000 {
+		t.Fatalf("unexpected snapshot base-unit balance: %d", got)
+	}
+	asset, ok := snapshot["asset"].(token.Asset)
+	if !ok {
+		t.Fatalf("unexpected asset snapshot type: %T", snapshot["asset"])
+	}
+	if asset.Symbol != "MHC" || asset.Decimals != 6 {
+		t.Fatalf("unexpected asset metadata: %+v", asset)
+	}
+}
+
+func TestUtilityCoinLegacyFloatStateMigration(t *testing.T) {
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, "legacy_state.json")
+	auditPath := filepath.Join(tmp, "legacy_audit.jsonl")
+
+	legacyState := map[string]any{
+		"schema_version": 1,
+		"symbol":         "MHC",
+		"minter":         "protocol",
+		"balances": map[string]float64{
+			"edge-a": 7.5,
+			"edge-b": 2.25,
+		},
+		"txns": []map[string]any{
+			{
+				"type":      "mint",
+				"to":        "edge-a",
+				"amount":    7.5,
+				"timestamp": "2025-01-01T00:00:00Z",
+			},
+		},
+		"total_supply": 9.75,
+	}
+	raw, err := json.Marshal(legacyState)
+	if err != nil {
+		t.Fatalf("marshal legacy state: %v", err)
+	}
+	if err := os.WriteFile(statePath, raw, 0o600); err != nil {
+		t.Fatalf("write legacy state: %v", err)
+	}
+
+	ledger, err := token.NewPersistentLedger("MHC", "protocol", statePath, auditPath)
+	if err != nil {
+		t.Fatalf("load legacy ledger: %v", err)
+	}
+	if got := ledger.BalanceUnits("edge-a"); got != 7500000 {
+		t.Fatalf("unexpected migrated edge-a units: %d", got)
+	}
+	if got := ledger.BalanceUnits("edge-b"); got != 2250000 {
+		t.Fatalf("unexpected migrated edge-b units: %d", got)
+	}
+	if got := ledger.Balance("edge-a"); got != 7.5 {
+		t.Fatalf("unexpected migrated edge-a balance: %.4f", got)
+	}
+
+	backupPath := filepath.Join(tmp, "migrated_state.json")
+	if err := ledger.Backup(backupPath); err != nil {
+		t.Fatalf("backup migrated ledger: %v", err)
+	}
+	backupRaw, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("read migrated backup: %v", err)
+	}
+	var migrated struct {
+		SchemaVersion    int              `json:"schema_version"`
+		BalancesUnits    map[string]int64 `json:"balances_units"`
+		TotalSupplyUnits int64            `json:"total_supply_units"`
+	}
+	if err := json.Unmarshal(backupRaw, &migrated); err != nil {
+		t.Fatalf("parse migrated backup: %v", err)
+	}
+	if migrated.SchemaVersion != 2 {
+		t.Fatalf("unexpected migrated schema version: %d", migrated.SchemaVersion)
+	}
+	if got := migrated.BalancesUnits["edge-a"]; got != 7500000 {
+		t.Fatalf("unexpected persisted migrated edge-a units: %d", got)
+	}
+	if migrated.TotalSupplyUnits != 9750000 {
+		t.Fatalf("unexpected persisted total supply units: %d", migrated.TotalSupplyUnits)
+	}
+}
+
+func TestUtilityAssetRegistry(t *testing.T) {
+	registry := token.NewRegistryWithDefaults()
+	mhc, ok := registry.Get("mhc")
+	if !ok {
+		t.Fatal("expected default MHC asset")
+	}
+	if mhc.Decimals != 6 {
+		t.Fatalf("unexpected default decimals: %d", mhc.Decimals)
+	}
+
+	if err := registry.Register(token.Asset{Symbol: "USDX", Decimals: 2, MaxSupplyUnits: 100000000}); err != nil {
+		t.Fatalf("register asset failed: %v", err)
+	}
+	usdx, ok := registry.Get("usdx")
+	if !ok {
+		t.Fatal("expected USDX asset")
+	}
+	if usdx.MaxSupplyUnits != 100000000 {
+		t.Fatalf("unexpected max supply units: %d", usdx.MaxSupplyUnits)
+	}
+	items := registry.List()
+	if len(items) < 2 {
+		t.Fatalf("expected at least 2 assets, got %d", len(items))
 	}
 }


### PR DESCRIPTION
## Summary
- add optional bridge settlement execution with deterministic settlement records
- implement burn -> release flow with refund fallback on mint/release failure
- support registry-backed multi-asset settlement ledgers and per-asset minters
- harden utility ledger with integer base-unit accounting, burn transactions, and legacy float-state migration
- expose settlement controls in runtime API and Python SDK (`settle`, `settlement_minter`)
- document env-driven multi-asset rollout and compose templates for single-asset default vs optional multi-asset mode

## Validation
- go test ./...
- docker compose config

## Files of note
- internal/bridge/bridge.go
- internal/token/ledger.go
- internal/token/registry.go
- internal/pyapi/api.go
- sdk/python/mohawk/client.py
- test/bridge_hybrid_test.go
- test/utility_coin_durability_test.go
