### PR TITLE
Security hardening fixes per Eddie notes

### DIFF
--- a/cmd/aggregator/main.go
+++ b/cmd/aggregator/main.go
@@ -7,7 +7,10 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
+
+	"github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/internal/tpm"
 )
 
 type Update struct {
@@ -47,13 +50,54 @@ func aggregateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := verifyFormalByzantineCheck(); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusFailedDependency)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":            "failed",
+			"formal_check_pass": false,
+			"message":           err.Error(),
+		})
+		return
+	}
+
 	fmt.Printf("Aggregating %d updates\n", len(updates))
 
 	w.Header().Set("Content-Type", "application/json")
-	// Satisfy linter with error check
-	if err := json.NewEncoder(w).Encode(map[string]string{"status": "success"}); err != nil {
+	if err := json.NewEncoder(w).Encode(map[string]any{"status": "success", "formal_check_pass": true}); err != nil {
 		log.Printf("failed to encode: %v", err)
 	}
+}
+
+func verifyFormalByzantineCheck() error {
+	totalNodes, hasTotal, err := parseOptionalIntEnv("AGGREGATOR_TOTAL_NODES")
+	if err != nil {
+		return err
+	}
+	maliciousNodes, hasMalicious, err := parseOptionalIntEnv("AGGREGATOR_MALICIOUS_NODES")
+	if err != nil {
+		return err
+	}
+	if !hasTotal && !hasMalicious {
+		return nil
+	}
+	if !hasTotal || !hasMalicious {
+		return fmt.Errorf("AGGREGATOR_TOTAL_NODES and AGGREGATOR_MALICIOUS_NODES must both be set for formal checks")
+	}
+	_, checkErr := tpm.VerifyByzantineResilience(totalNodes, maliciousNodes)
+	return checkErr
+}
+
+func parseOptionalIntEnv(key string) (int, bool, error) {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return 0, false, nil
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, true, fmt.Errorf("invalid %s=%q: %w", key, raw, err)
+	}
+	return v, true, nil
 }
 
 func main() {

--- a/cmd/aggregator/main_test.go
+++ b/cmd/aggregator/main_test.go
@@ -44,3 +44,29 @@ func TestAggregateHandler_RejectsOversizedBody(t *testing.T) {
 		t.Fatalf("expected 400 for oversized payload, got %d", rr.Code)
 	}
 }
+
+func TestAggregateHandler_FailsWhenFormalByzantineCheckFails(t *testing.T) {
+	t.Setenv("AGGREGATOR_TOTAL_NODES", "10")
+	t.Setenv("AGGREGATOR_MALICIOUS_NODES", "6")
+	req := httptest.NewRequest(http.MethodPost, "/aggregate", strings.NewReader(`[{"id":"n1","value":1}]`))
+	rr := httptest.NewRecorder()
+
+	aggregateHandler(rr, req)
+
+	if rr.Code != http.StatusFailedDependency {
+		t.Fatalf("expected 424 for formal check failure, got %d", rr.Code)
+	}
+}
+
+func TestAggregateHandler_PassesWhenFormalByzantineCheckPasses(t *testing.T) {
+	t.Setenv("AGGREGATOR_TOTAL_NODES", "101")
+	t.Setenv("AGGREGATOR_MALICIOUS_NODES", "40")
+	req := httptest.NewRequest(http.MethodPost, "/aggregate", strings.NewReader(`[{"id":"n1","value":1}]`))
+	rr := httptest.NewRecorder()
+
+	aggregateHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+}

--- a/cmd/fl-aggregator/main.go
+++ b/cmd/fl-aggregator/main.go
@@ -16,12 +16,16 @@ package main
 import (
 	"crypto/subtle"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"math"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
+
+	"github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/internal/tpm"
 )
 
 type GradPayload struct {
@@ -67,6 +71,17 @@ func handleSubmit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := verifyFormalByzantineCheck(); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusFailedDependency)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":            "failed",
+			"formal_check_pass": false,
+			"message":           err.Error(),
+		})
+		return
+	}
+
 	maxNorm := 10.0
 	norm := 0.0
 	for _, g := range p.Grads {
@@ -81,5 +96,38 @@ func handleSubmit(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Printf("received %d grads from %s (clipped)", len(p.Grads), p.NodeID)
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]any{"status": "success", "formal_check_pass": true})
+}
+
+func verifyFormalByzantineCheck() error {
+	totalNodes, hasTotal, err := parseOptionalIntEnv("FL_AGGREGATOR_TOTAL_NODES")
+	if err != nil {
+		return err
+	}
+	maliciousNodes, hasMalicious, err := parseOptionalIntEnv("FL_AGGREGATOR_MALICIOUS_NODES")
+	if err != nil {
+		return err
+	}
+	if !hasTotal && !hasMalicious {
+		return nil
+	}
+	if !hasTotal || !hasMalicious {
+		return fmt.Errorf("FL_AGGREGATOR_TOTAL_NODES and FL_AGGREGATOR_MALICIOUS_NODES must both be set for formal checks")
+	}
+	_, checkErr := tpm.VerifyByzantineResilience(totalNodes, maliciousNodes)
+	return checkErr
+}
+
+func parseOptionalIntEnv(key string) (int, bool, error) {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return 0, false, nil
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, true, fmt.Errorf("invalid %s=%q: %w", key, raw, err)
+	}
+	return v, true, nil
 }

--- a/cmd/fl-aggregator/main_test.go
+++ b/cmd/fl-aggregator/main_test.go
@@ -44,3 +44,29 @@ func TestHandleSubmit_RejectsOversizedBody(t *testing.T) {
 		t.Fatalf("expected 400 for oversized payload, got %d", rr.Code)
 	}
 }
+
+func TestHandleSubmit_FailsWhenFormalByzantineCheckFails(t *testing.T) {
+	t.Setenv("FL_AGGREGATOR_TOTAL_NODES", "10")
+	t.Setenv("FL_AGGREGATOR_MALICIOUS_NODES", "6")
+	req := httptest.NewRequest(http.MethodPost, "/fl/submit", strings.NewReader(`{"node_id":"n1","grads":[1,2,3]}`))
+	rr := httptest.NewRecorder()
+
+	handleSubmit(rr, req)
+
+	if rr.Code != http.StatusFailedDependency {
+		t.Fatalf("expected 424 for formal check failure, got %d", rr.Code)
+	}
+}
+
+func TestHandleSubmit_PassesWhenFormalByzantineCheckPasses(t *testing.T) {
+	t.Setenv("FL_AGGREGATOR_TOTAL_NODES", "101")
+	t.Setenv("FL_AGGREGATOR_MALICIOUS_NODES", "40")
+	req := httptest.NewRequest(http.MethodPost, "/fl/submit", strings.NewReader(`{"node_id":"n1","grads":[1,2,3]}`))
+	rr := httptest.NewRecorder()
+
+	handleSubmit(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+}

--- a/internal/aggregator.go
+++ b/internal/aggregator.go
@@ -38,6 +38,7 @@ const (
 type Aggregator struct {
 	Tier        Tier
 	Accountant  *RDPAccountant
+	DPSigma     float64
 	Liveness    *StragglerMonitor
 	Convergence *ConvergenceMonitor
 	MeshPlan    hva.Plan
@@ -73,6 +74,7 @@ func NewAggregator(t Tier) *Aggregator {
 	return &Aggregator{
 		Tier:        t,
 		Accountant:  NewRDPAccountant(dp.TargetEpsilon, dp.Delta),
+		DPSigma:     dp.Sigma,
 		Liveness:    NewStragglerMonitor(),
 		Convergence: NewConvergenceMonitor(0.1, 0.01),
 		MeshPlan:    meshPlan,
@@ -95,6 +97,9 @@ func (a *Aggregator) ProcessUpdates(activeNodes int, totalNodes int, gradNorm fl
 	metrics.ObserveConsensus(fmt.Sprintf("tier-%d", a.Tier), activeNodes, totalNodes)
 
 	// Active Guard: Theorem 2 (Privacy Budget)
+	if err := a.Accountant.RecordGaussianStepRDP(a.DPSigma); err != nil {
+		return fmt.Errorf("privacy accounting failed: %w", err)
+	}
 	if err := a.Accountant.CheckBudget(); err != nil {
 		return fmt.Errorf("privacy guard triggered: %w", err)
 	}

--- a/internal/rdp_accountant.go
+++ b/internal/rdp_accountant.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"strconv"
 	"sync"
 )
 
@@ -142,10 +141,5 @@ func ratFromFloat64(v float64) *big.Rat {
 	if math.IsNaN(v) || math.IsInf(v, 0) {
 		return new(big.Rat)
 	}
-	s := strconv.FormatFloat(v, 'f', 18, 64)
-	rat := new(big.Rat)
-	if _, ok := rat.SetString(s); ok {
-		return rat
-	}
-	return new(big.Rat)
+	return new(big.Rat).SetFloat64(v)
 }

--- a/internal/rdp_accountant.go
+++ b/internal/rdp_accountant.go
@@ -19,6 +19,8 @@ package internal
 import (
 	"fmt"
 	"math"
+	"math/big"
+	"strconv"
 	"sync"
 )
 
@@ -26,27 +28,53 @@ import (
 // It implements Theorem 2: sequential composition of RDP mechanisms.
 type RDPAccountant struct {
 	mu           sync.RWMutex
-	Alpha        float64 // Rényi divergence order
-	TotalEpsilon float64 // Cumulative RDP epsilon
-	MaxBudget    float64 // Target (ε, δ)-DP limit (e.g., 2.0)
-	TargetDelta  float64 // Fixed delta (e.g., 10⁻⁵)
+	Alpha        float64  // Rényi divergence order
+	TotalEpsilon *big.Rat // Cumulative RDP epsilon
+	MaxBudget    *big.Rat // Target (ε, δ)-DP limit (e.g., 2.0)
+	TargetDelta  float64  // Fixed delta (e.g., 10⁻⁵)
 }
 
 // NewRDPAccountant initializes the accountant with research-backed defaults.
 func NewRDPAccountant(maxEpsilon float64, delta float64) *RDPAccountant {
+	maxBudget := new(big.Rat)
+	if maxBudget.SetFloat64(maxEpsilon) == nil {
+		maxBudget = new(big.Rat)
+	}
 	return &RDPAccountant{
-		Alpha:       10.0, // Optimized alpha for hierarchical composition
-		MaxBudget:   maxEpsilon,
-		TargetDelta: delta,
+		Alpha:        10.0, // Optimized alpha for hierarchical composition
+		TotalEpsilon: new(big.Rat),
+		MaxBudget:    maxBudget,
+		TargetDelta:  delta,
 	}
 }
 
 // RecordStep adds the RDP epsilon of a new mechanism to the running sum.
 // Reference: /proofs/differential_privacy.md
 func (a *RDPAccountant) RecordStep(epsilon float64) {
+	rat := ratFromFloat64(epsilon)
+	a.RecordStepRat(rat)
+}
+
+// RecordStepRat adds the RDP epsilon using rational arithmetic to avoid
+// cumulative floating-point drift across many composition steps.
+func (a *RDPAccountant) RecordStepRat(epsilon *big.Rat) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	a.TotalEpsilon += epsilon
+	if epsilon == nil {
+		return
+	}
+	a.TotalEpsilon.Add(a.TotalEpsilon, epsilon)
+}
+
+// RecordGaussianStepRDP records one Gaussian mechanism step using the standard
+// RDP composition formula epsilon(alpha) = alpha/(2*sigma^2).
+func (a *RDPAccountant) RecordGaussianStepRDP(sigma float64) error {
+	if sigma <= 0 {
+		return fmt.Errorf("sigma must be positive")
+	}
+	epsilon := a.Alpha / (2.0 * sigma * sigma)
+	a.RecordStep(epsilon)
+	return nil
 }
 
 // GetCurrentEpsilon converts cumulative RDP to standard (ε, δ)-DP.
@@ -55,19 +83,69 @@ func (a *RDPAccountant) GetCurrentEpsilon() float64 {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
-	if a.TotalEpsilon == 0 {
+	if a.TotalEpsilon.Sign() == 0 {
 		return 0
 	}
 
 	conversion := math.Log(1.0/a.TargetDelta) / (a.Alpha - 1.0)
-	return a.TotalEpsilon + conversion
+	total, _ := a.TotalEpsilon.Float64()
+	return total + conversion
+}
+
+// GetCurrentEpsilonRat returns the current epsilon as a rational value derived
+// from the rational ledger plus the converted (epsilon, delta) term.
+func (a *RDPAccountant) GetCurrentEpsilonRat() *big.Rat {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if a.TotalEpsilon.Sign() == 0 {
+		return new(big.Rat)
+	}
+	conversion := math.Log(1.0/a.TargetDelta) / (a.Alpha - 1.0)
+	current := new(big.Rat).Set(a.TotalEpsilon)
+	current.Add(current, ratFromFloat64(conversion))
+	return current
+}
+
+// MaxBudgetFloat returns the configured epsilon budget as float64 for callers
+// that need stable formatting/logging.
+func (a *RDPAccountant) MaxBudgetFloat() float64 {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if a.MaxBudget == nil {
+		return 0
+	}
+	v, _ := a.MaxBudget.Float64()
+	return v
 }
 
 // CheckBudget verifies if the system is still within the verified privacy bound.
 func (a *RDPAccountant) CheckBudget() error {
-	current := a.GetCurrentEpsilon()
-	if current > a.MaxBudget {
-		return fmt.Errorf("privacy budget exhausted: current ε=%.2f exceeds limit ε=%.2f", current, a.MaxBudget)
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	if a.TotalEpsilon.Sign() == 0 {
+		return nil
+	}
+
+	conversion := math.Log(1.0/a.TargetDelta) / (a.Alpha - 1.0)
+	current := new(big.Rat).Set(a.TotalEpsilon)
+	current.Add(current, ratFromFloat64(conversion))
+	if current.Cmp(a.MaxBudget) > 0 {
+		currentFloat, _ := current.Float64()
+		maxFloat, _ := a.MaxBudget.Float64()
+		return fmt.Errorf("privacy budget exhausted: current ε=%.2f exceeds limit ε=%.2f", currentFloat, maxFloat)
 	}
 	return nil
+}
+
+func ratFromFloat64(v float64) *big.Rat {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return new(big.Rat)
+	}
+	s := strconv.FormatFloat(v, 'f', 18, 64)
+	rat := new(big.Rat)
+	if _, ok := rat.SetString(s); ok {
+		return rat
+	}
+	return new(big.Rat)
 }

--- a/internal/tpm/hardware_policy_default.go
+++ b/internal/tpm/hardware_policy_default.go
@@ -1,0 +1,7 @@
+//go:build !production || (!darwin && !windows)
+
+package tpm
+
+func requireHardwareTPMProduction() bool {
+	return false
+}

--- a/internal/tpm/hardware_policy_production_darwin_windows.go
+++ b/internal/tpm/hardware_policy_production_darwin_windows.go
@@ -1,0 +1,7 @@
+//go:build production && (darwin || windows)
+
+package tpm
+
+func requireHardwareTPMProduction() bool {
+	return true
+}

--- a/internal/tpm/tpm.go
+++ b/internal/tpm/tpm.go
@@ -451,6 +451,10 @@ func getAuthority() (*Authority, error) {
 		}
 	}
 
+	if requireHardwareTPMProduction() {
+		return nil, fmt.Errorf("software TPM fallback is disabled for this production target; configure MOHAWK_TPM_CA_CERT_FILE and MOHAWK_TPM_CA_KEY_FILE")
+	}
+
 	if defaultAuthority != nil && defaultAuthorityE == nil && !authorityNeedsRotation(defaultAuthority.cert) {
 		return defaultAuthority, nil
 	}
@@ -526,6 +530,9 @@ func loadAuthorityCertFromFile(certPath string) (*Authority, error) {
 }
 
 func allowAuthorityFallback(certPath string, keyPath string, loadErr error) bool {
+	if requireHardwareTPMProduction() {
+		return false
+	}
 	if os.IsNotExist(loadErr) {
 		return true
 	}

--- a/internal/wasmhost/host.go
+++ b/internal/wasmhost/host.go
@@ -131,7 +131,7 @@ func totalFunctionCount(wasmBin []byte) (int, error) {
 			return 0, fmt.Errorf("section exceeds module bounds")
 		}
 
-		section := wasmBin[offset : offset+uint64(sectionSize)]
+		section := wasmBin[offset:][:sectionSize]
 		offset += uint64(sectionSize)
 
 		switch sectionID {

--- a/internal/wasmhost/host.go
+++ b/internal/wasmhost/host.go
@@ -113,11 +113,12 @@ func totalFunctionCount(wasmBin []byte) (int, error) {
 		return 0, fmt.Errorf("unsupported wasm version")
 	}
 
-	offset := 8
+	offset := uint64(8)
 	var importedFuncs uint32
 	var definedFuncs uint32
+	bufLen := uint64(len(wasmBin))
 
-	for offset < len(wasmBin) {
+	for offset < bufLen {
 		sectionID := wasmBin[offset]
 		offset++
 
@@ -125,13 +126,13 @@ func totalFunctionCount(wasmBin []byte) (int, error) {
 		if err != nil {
 			return 0, fmt.Errorf("read section size: %w", err)
 		}
-		offset += n
-		if offset+int(sectionSize) > len(wasmBin) {
+		offset += uint64(n)
+		if uint64(sectionSize) > bufLen-offset {
 			return 0, fmt.Errorf("section exceeds module bounds")
 		}
 
-		section := wasmBin[offset : offset+int(sectionSize)]
-		offset += int(sectionSize)
+		section := wasmBin[offset : offset+uint64(sectionSize)]
+		offset += uint64(sectionSize)
 
 		switch sectionID {
 		case 2:

--- a/internal/wasmhost/host.go
+++ b/internal/wasmhost/host.go
@@ -32,6 +32,11 @@ import (
 // on restarts of long-running node-agents.
 const compilationCacheDir = "/tmp/mohawk-wasm-cache"
 
+const (
+	MaxModuleBytes   = 10 * 1024 * 1024
+	MaxFunctionCount = 1000
+)
+
 // Host manages the WebAssembly runtime environment for zk-SNARK verification.
 type Host struct {
 	runtime wazero.Runtime
@@ -56,6 +61,10 @@ func NewRegistry() *Registry {
 // and reused on subsequent startups, and enables WASM SIMD intrinsics where
 // the host CPU supports them (detected automatically by wazero).
 func NewHost(ctx context.Context, wasmBin []byte) (*Host, error) {
+	if err := ValidateModuleLimits(wasmBin); err != nil {
+		return nil, err
+	}
+
 	cfg := wazero.NewRuntimeConfig().
 		WithCompilationCache(newCompilationCache(ctx))
 
@@ -71,6 +80,185 @@ func NewHost(ctx context.Context, wasmBin []byte) (*Host, error) {
 		runtime: r,
 		mod:     mod,
 	}, nil
+}
+
+// ValidateModuleLimits enforces static module-level safety guardrails before
+// any JIT/AOT compilation work is performed.
+func ValidateModuleLimits(wasmBin []byte) error {
+	if len(wasmBin) == 0 {
+		return fmt.Errorf("empty wasm module")
+	}
+	if len(wasmBin) > MaxModuleBytes {
+		return fmt.Errorf("wasm module size %d exceeds max %d bytes", len(wasmBin), MaxModuleBytes)
+	}
+
+	funcCount, err := totalFunctionCount(wasmBin)
+	if err != nil {
+		return fmt.Errorf("invalid wasm module: %w", err)
+	}
+	if funcCount > MaxFunctionCount {
+		return fmt.Errorf("wasm module function count %d exceeds max %d", funcCount, MaxFunctionCount)
+	}
+	return nil
+}
+
+func totalFunctionCount(wasmBin []byte) (int, error) {
+	if len(wasmBin) < 8 {
+		return 0, fmt.Errorf("module too short")
+	}
+	if wasmBin[0] != 0x00 || wasmBin[1] != 0x61 || wasmBin[2] != 0x73 || wasmBin[3] != 0x6d {
+		return 0, fmt.Errorf("bad wasm magic")
+	}
+	if wasmBin[4] != 0x01 || wasmBin[5] != 0x00 || wasmBin[6] != 0x00 || wasmBin[7] != 0x00 {
+		return 0, fmt.Errorf("unsupported wasm version")
+	}
+
+	offset := 8
+	var importedFuncs uint32
+	var definedFuncs uint32
+
+	for offset < len(wasmBin) {
+		sectionID := wasmBin[offset]
+		offset++
+
+		sectionSize, n, err := readVarUint32(wasmBin[offset:])
+		if err != nil {
+			return 0, fmt.Errorf("read section size: %w", err)
+		}
+		offset += n
+		if offset+int(sectionSize) > len(wasmBin) {
+			return 0, fmt.Errorf("section exceeds module bounds")
+		}
+
+		section := wasmBin[offset : offset+int(sectionSize)]
+		offset += int(sectionSize)
+
+		switch sectionID {
+		case 2:
+			count, err := countImportedFunctions(section)
+			if err != nil {
+				return 0, fmt.Errorf("parse import section: %w", err)
+			}
+			importedFuncs = count
+		case 3:
+			count, _, err := readVarUint32(section)
+			if err != nil {
+				return 0, fmt.Errorf("parse function section: %w", err)
+			}
+			definedFuncs = count
+		}
+	}
+
+	return int(importedFuncs + definedFuncs), nil
+}
+
+func countImportedFunctions(section []byte) (uint32, error) {
+	entryCount, i, err := readVarUint32(section)
+	if err != nil {
+		return 0, err
+	}
+
+	var importedFuncs uint32
+	for entry := uint32(0); entry < entryCount; entry++ {
+		if err := skipName(section, &i); err != nil {
+			return 0, err
+		}
+		if err := skipName(section, &i); err != nil {
+			return 0, err
+		}
+		if i >= len(section) {
+			return 0, fmt.Errorf("truncated import descriptor")
+		}
+		kind := section[i]
+		i++
+
+		switch kind {
+		case 0x00: // func
+			_, n, err := readVarUint32(section[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+			importedFuncs++
+		case 0x01: // table
+			if i >= len(section) {
+				return 0, fmt.Errorf("truncated table import")
+			}
+			i++ // elemtype
+			if err := skipLimits(section, &i); err != nil {
+				return 0, err
+			}
+		case 0x02: // memory
+			if err := skipLimits(section, &i); err != nil {
+				return 0, err
+			}
+		case 0x03: // global
+			if i+2 > len(section) {
+				return 0, fmt.Errorf("truncated global import")
+			}
+			i += 2 // valtype + mutability
+		default:
+			return 0, fmt.Errorf("unsupported import kind %d", kind)
+		}
+	}
+
+	return importedFuncs, nil
+}
+
+func skipName(data []byte, i *int) error {
+	if *i >= len(data) {
+		return fmt.Errorf("truncated name")
+	}
+	nameLen, n, err := readVarUint32(data[*i:])
+	if err != nil {
+		return err
+	}
+	*i += n
+	if *i+int(nameLen) > len(data) {
+		return fmt.Errorf("name exceeds bounds")
+	}
+	*i += int(nameLen)
+	return nil
+}
+
+func skipLimits(data []byte, i *int) error {
+	if *i >= len(data) {
+		return fmt.Errorf("truncated limits")
+	}
+	flags, n, err := readVarUint32(data[*i:])
+	if err != nil {
+		return err
+	}
+	*i += n
+
+	if _, n, err = readVarUint32(data[*i:]); err != nil {
+		return err
+	}
+	*i += n
+
+	if flags&0x01 != 0 {
+		if _, n, err = readVarUint32(data[*i:]); err != nil {
+			return err
+		}
+		*i += n
+	}
+	return nil
+}
+
+func readVarUint32(data []byte) (uint32, int, error) {
+	var value uint32
+	var shift uint
+	for i, b := range data {
+		value |= uint32(b&0x7f) << shift
+		if b&0x80 == 0 {
+			return value, i + 1, nil
+		}
+		shift += 7
+		if shift >= 35 {
+			return 0, 0, fmt.Errorf("varuint32 too large")
+		}
+	}
+	return 0, 0, fmt.Errorf("truncated varuint32")
 }
 
 // newCompilationCache creates a filesystem-backed compilation cache at

--- a/internal/wasmhost/host_limits_test.go
+++ b/internal/wasmhost/host_limits_test.go
@@ -1,0 +1,71 @@
+package wasmhost
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+func TestValidateModuleLimits_RejectsOversizeModule(t *testing.T) {
+	wasm := bytes.Repeat([]byte{0x00}, MaxModuleBytes+1)
+	if err := ValidateModuleLimits(wasm); err == nil || !strings.Contains(err.Error(), "exceeds max") {
+		t.Fatalf("expected oversize module rejection, got %v", err)
+	}
+}
+
+func TestValidateModuleLimits_RejectsTooManyFunctions(t *testing.T) {
+	wasm := minimalWasmWithFunctions(MaxFunctionCount + 1)
+	if err := ValidateModuleLimits(wasm); err == nil || !strings.Contains(err.Error(), "function count") {
+		t.Fatalf("expected function count rejection, got %v", err)
+	}
+}
+
+func TestValidateModuleLimits_AcceptsReasonableModule(t *testing.T) {
+	wasm := minimalWasmWithFunctions(10)
+	if err := ValidateModuleLimits(wasm); err != nil {
+		t.Fatalf("expected module to pass limits, got %v", err)
+	}
+}
+
+func minimalWasmWithFunctions(functionCount int) []byte {
+	out := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00}
+
+	// Type section: one function type with no params/results.
+	typePayload := []byte{0x01, 0x60, 0x00, 0x00}
+	out = appendSection(out, 1, typePayload)
+
+	// Function section: N functions all referencing type index 0.
+	funcPayload := append(encodeVarUint32(uint32(functionCount)), bytes.Repeat([]byte{0x00}, functionCount)...)
+	out = appendSection(out, 3, funcPayload)
+
+	// Export section: export first function as "verify_proof" if available.
+	if functionCount > 0 {
+		exportPayload := []byte{0x01, 0x0c}
+		exportPayload = append(exportPayload, []byte("verify_proof")...)
+		exportPayload = append(exportPayload, 0x00, 0x00)
+		out = appendSection(out, 7, exportPayload)
+	}
+
+	// Code section: N empty function bodies.
+	codePayload := encodeVarUint32(uint32(functionCount))
+	for i := 0; i < functionCount; i++ {
+		codePayload = append(codePayload, 0x02, 0x00, 0x0b)
+	}
+	out = appendSection(out, 10, codePayload)
+
+	return out
+}
+
+func appendSection(wasm []byte, sectionID byte, payload []byte) []byte {
+	wasm = append(wasm, sectionID)
+	wasm = append(wasm, encodeVarUint32(uint32(len(payload)))...)
+	wasm = append(wasm, payload...)
+	return wasm
+}
+
+func encodeVarUint32(v uint32) []byte {
+	buf := make([]byte, binary.MaxVarintLen32)
+	n := binary.PutUvarint(buf, uint64(v))
+	return buf[:n]
+}

--- a/sdk/python/mohawk/client.py
+++ b/sdk/python/mohawk/client.py
@@ -34,6 +34,16 @@ from .high_level import (
 
 JsonDict = Dict[str, Any]
 BufferLike = Union[bytes, bytearray, memoryview]
+MAX_GRADIENT_ELEMENTS = 1_000_000
+
+
+def _validate_gradient_count(count: int) -> None:
+    if count < 0:
+        raise AggregationError(f"invalid gradient count: {count}")
+    if count > MAX_GRADIENT_ELEMENTS:
+        raise AggregationError(
+            f"gradient length {count} exceeds MAX_GRADIENT_ELEMENTS={MAX_GRADIENT_ELEMENTS}"
+        )
 
 
 class ZeroCopyBridge:
@@ -94,6 +104,7 @@ class ZeroCopyBridge:
             float_view = memoryview(bytearray(view.tobytes())).cast("f")
 
         if self.lib is None or not self.has_symbol("CompressGradientsZeroCopy"):
+            _validate_gradient_count(len(float_view))
             return {
                 "success": True,
                 "message": "Gradients compressed (python zero-copy fallback)",
@@ -110,6 +121,8 @@ class ZeroCopyBridge:
             ctypes.c_double,
         ]
         func.restype = ctypes.c_void_p
+
+        _validate_gradient_count(len(float_view))
 
         holder = bytearray(float_view.tobytes())
         array_type = ctypes.c_float * len(float_view)
@@ -307,6 +320,7 @@ class MohawkNode:
         max_norm: float = 1.0,
     ) -> JsonDict:
         grads = list(gradients)
+        _validate_gradient_count(len(grads))
         payload = {"gradients": grads, "format": format, "max_norm": max_norm}
         result = self.bridge.invoke_json("CompressGradients", payload)
         if result.get("success", False):

--- a/sdk/python/mohawk/client.py
+++ b/sdk/python/mohawk/client.py
@@ -96,6 +96,9 @@ class ZeroCopyBridge:
         max_norm: float = 1.0,
     ) -> JsonDict:
         view = self.view(gradients)
+        # Validate element count based on raw bytes before any buffer materialization
+        # to prevent memory/CPU DoS from oversized payloads.
+        _validate_gradient_count(view.nbytes // 4)
         if view.format in {"f", "=f", "<f"}:
             float_view = view
         elif view.format in {"B", "b", "c"}:
@@ -104,7 +107,6 @@ class ZeroCopyBridge:
             float_view = memoryview(bytearray(view.tobytes())).cast("f")
 
         if self.lib is None or not self.has_symbol("CompressGradientsZeroCopy"):
-            _validate_gradient_count(len(float_view))
             return {
                 "success": True,
                 "message": "Gradients compressed (python zero-copy fallback)",
@@ -121,8 +123,6 @@ class ZeroCopyBridge:
             ctypes.c_double,
         ]
         func.restype = ctypes.c_void_p
-
-        _validate_gradient_count(len(float_view))
 
         holder = bytearray(float_view.tobytes())
         array_type = ctypes.c_float * len(float_view)

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -3,6 +3,7 @@
 import array
 
 import pytest
+import mohawk.client as client_module
 from mohawk import (
     AggregationError,
     BridgeTransferIntent,
@@ -105,6 +106,17 @@ class TestMohawkNode:
         gradients = array.array("f", [0.1, -0.2, 0.3, 0.4])
         result = node.compress_gradients_zero_copy(memoryview(gradients), format="fp16")
         assert result["success"] is True
+
+    def test_compress_gradients_rejects_oversized_vector(self, node, monkeypatch):
+        monkeypatch.setattr(client_module, "MAX_GRADIENT_ELEMENTS", 2)
+        with pytest.raises(AggregationError):
+            node.compress_gradients([0.1, 0.2, 0.3], format="fp16")
+
+    def test_compress_gradients_zero_copy_rejects_oversized_vector(self, node, monkeypatch):
+        monkeypatch.setattr(client_module, "MAX_GRADIENT_ELEMENTS", 2)
+        gradients = array.array("f", [0.1, 0.2, 0.3])
+        with pytest.raises(AggregationError):
+            node.compress_gradients_zero_copy(memoryview(gradients), format="fp16")
 
     def test_batch_verify(self, node):
         """Test batch proof verification API."""

--- a/test/rdp_accountant_test.go
+++ b/test/rdp_accountant_test.go
@@ -1,6 +1,8 @@
 package test
 
 import (
+	"math"
+	"math/big"
 	"testing"
 
 	internal "github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/internal"
@@ -86,10 +88,38 @@ func TestNewAggregator_UsesDPConfig(t *testing.T) {
 	t.Setenv("MOHAWK_DP_DELTA", "0.00002")
 
 	agg := internal.NewAggregator(internal.Regional)
-	if agg.Accountant.MaxBudget != 15.5 {
-		t.Fatalf("expected accountant max budget=15.5, got %f", agg.Accountant.MaxBudget)
+	if agg.Accountant.MaxBudgetFloat() != 15.5 {
+		t.Fatalf("expected accountant max budget=15.5, got %f", agg.Accountant.MaxBudgetFloat())
 	}
 	if agg.Accountant.TargetDelta != 2e-5 {
 		t.Fatalf("expected accountant delta=2e-5, got %f", agg.Accountant.TargetDelta)
+	}
+}
+
+func TestRDPAccountant_RecordStepRat_Precision(t *testing.T) {
+	acc := internal.NewRDPAccountant(10.0, 1e-5)
+
+	step := new(big.Rat)
+	if _, ok := step.SetString("0.1"); !ok {
+		t.Fatal("failed to build rational step")
+	}
+	for i := 0; i < 10; i++ {
+		acc.RecordStepRat(step)
+	}
+
+	total, _ := acc.TotalEpsilon.Float64()
+	if math.Abs(total-1.0) > 1e-12 {
+		t.Fatalf("expected exact rational accumulation to 1.0, got %.18f", total)
+	}
+}
+
+func TestRDPAccountant_RecordGaussianStepRDP(t *testing.T) {
+	acc := internal.NewRDPAccountant(100.0, 1e-5)
+	if err := acc.RecordGaussianStepRDP(1.0); err != nil {
+		t.Fatalf("unexpected gaussian step error: %v", err)
+	}
+	eps := acc.GetCurrentEpsilon()
+	if eps <= 0 {
+		t.Fatalf("expected positive epsilon after gaussian step, got %.6f", eps)
 	}
 }


### PR DESCRIPTION
## Summary\nThis PR implements the security/privacy hardening items from Eddie's notes and excludes all challenge-related files.\n\n### Included fixes\n- Privacy budget precision: moved RDP cumulative epsilon ledger arithmetic to rational math using big.Rat.\n- Epsilon standardization: unified privacy step accounting through Gaussian RDP composition in aggregator runtime path.\n- Formal failure handling: aggregator and FL aggregator now hard-fail with failed status when Byzantine/formal checks fail (no silent success).\n- Python SDK safety: added gradient size caps before ctypes/CGO bridge calls.\n- TPM production policy: added build-tag based hardware TPM enforcement to disable software fallback on production darwin/windows builds.\n- WASM DoS protections: added pre-JIT module limits (10MB max size, 1000 max functions) plus tests.\n\n### Tests\n- Added/updated unit tests for:\n  - RDP accountant rational precision and Gaussian step behavior\n  - formal hard-fail behavior in aggregator and FL aggregator handlers\n  - Python gradient size limit enforcement\n  - WASM module size/function-count limits\n\n### Scope confirmation\n- Challenge files were explicitly removed from this PR scope.\n\n### Validation note\n- Local full Go test execution in this container is currently blocked by a Go toolchain mismatch (stdlib/tool versions differ).\n