### PR TITLE
Add native Windows testnet GUI and EXE build target

### DIFF
--- a/.github/workflows/fedavg-benchmark-compare.yml
+++ b/.github/workflows/fedavg-benchmark-compare.yml
@@ -217,13 +217,16 @@ jobs:
           in_time_block = False
           delta = None
           for line in text.splitlines():
-            if "delta" in line and ("sec/op" in line or "ns/op" in line or "time/op" in line):
+            if ("sec/op" in line or "ns/op" in line or "time/op" in line) and ("vs base" in line or "delta" in line):
               in_time_block = True
               continue
             if in_time_block and line.strip().startswith("geomean"):
               m = re.search(r"([+-]?[0-9]+(?:\.[0-9]+)?)%", line)
               if m:
                 delta = float(m.group(1))
+              elif re.search(r'\b~\b', line):
+                # Statistically indistinguishable — treat as no regression.
+                delta = 0.0
               break
 
           if delta is None:
@@ -233,6 +236,10 @@ jobs:
                 m = re.search(r"([+-]?[0-9]+(?:\.[0-9]+)?)%", line)
                 if m:
                   delta = float(m.group(1))
+                  break
+                if re.search(r'\b~\b', line):
+                  # Statistically indistinguishable — treat as no regression.
+                  delta = 0.0
                   break
 
           if delta is None:

--- a/.github/workflows/fedavg-benchmark-compare.yml
+++ b/.github/workflows/fedavg-benchmark-compare.yml
@@ -211,36 +211,42 @@ jobs:
           import re
           from pathlib import Path
 
+          TIME_OPS = ("sec/op", "ns/op", "time/op")
+          TIME_HEADER_MARKERS = ("vs base", "delta")
+          PCT_RE = re.compile(r"([+-]?[0-9]+(?:\.[0-9]+)?)%")
+          TILDE_RE = re.compile(r"\b~\b")
+
+          def parse_geomean_delta(line):
+            """Return geomean delta from a benchstat geomean line, or None if unparseable."""
+            m = PCT_RE.search(line)
+            if m:
+              return float(m.group(1))
+            # Statistically indistinguishable (~) — treat as no regression.
+            if TILDE_RE.search(line):
+              return 0.0
+            return None
+
           threshold = float(os.environ["FEDAVG_REGRESSION_THRESHOLD_PCT"])
           text = Path(".benchmarks/fedavg/benchstat.txt").read_text(encoding="utf-8")
 
           in_time_block = False
           delta = None
           for line in text.splitlines():
-            if ("sec/op" in line or "ns/op" in line or "time/op" in line) and ("vs base" in line or "delta" in line):
+            has_time_metric = any(op in line for op in TIME_OPS)
+            has_header_marker = any(m in line for m in TIME_HEADER_MARKERS)
+            if has_time_metric and has_header_marker:
               in_time_block = True
               continue
             if in_time_block and line.strip().startswith("geomean"):
-              m = re.search(r"([+-]?[0-9]+(?:\.[0-9]+)?)%", line)
-              if m:
-                delta = float(m.group(1))
-              elif re.search(r'\b~\b', line):
-                # Statistically indistinguishable — treat as no regression.
-                delta = 0.0
+              delta = parse_geomean_delta(line)
               break
 
           if delta is None:
-            # Fallback: accept first geomean percentage if table headers differ.
+            # Fallback: accept first geomean line if table headers differ.
             for line in text.splitlines():
               if line.strip().startswith("geomean"):
-                m = re.search(r"([+-]?[0-9]+(?:\.[0-9]+)?)%", line)
-                if m:
-                  delta = float(m.group(1))
-                  break
-                if re.search(r'\b~\b', line):
-                  # Statistically indistinguishable — treat as no regression.
-                  delta = 0.0
-                  break
+                delta = parse_geomean_delta(line)
+                break
 
           if delta is None:
             print("error: unable to parse geomean regression from benchstat output")

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ results/**
 !results/go-live/attestations/tpm_attestation_production_closure.json
 !results/metrics/
 !results/metrics/scaling_evidence_spotlight_2026-04-11.md
+testnet-gui

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Sovereign Mohawk Protocol - Verification & Build System
 
-.PHONY: all build test audit lint refresh-proof-artifacts verify clean go-env build-python-lib install-python-sdk test-python-sdk metrics regional-shard full-stack-3-nodes full-stack-3-nodes-down sandbox-up sandbox-down forensics-drill forensics-drill-down forensics-rehearsal strict-auth-smoke-host strict-auth-smoke-container production-readiness mainnet-one-click go-live-gate go-live-gate-advisory go-live-gate-strict golden-path-e2e failure-injection-latency-check fedavg-scale-gate tpm-attestation-closure-check tpm-closure-summary ga-tag-ready-check release-performance-evidence openapi-spec capability-dashboard-matrix benchmark-gpu full-validation-fast full-validation-deep validation-trends validation-diff-summary workflow-pin-check fips-runtime-check fips-regression pqc-health tamper-evident-export tamper-evident-e2e-test
+.PHONY: all build test audit lint refresh-proof-artifacts verify clean go-env build-python-lib install-python-sdk test-python-sdk metrics regional-shard full-stack-3-nodes full-stack-3-nodes-down sandbox-up sandbox-down forensics-drill forensics-drill-down forensics-rehearsal strict-auth-smoke-host strict-auth-smoke-container production-readiness mainnet-one-click go-live-gate go-live-gate-advisory go-live-gate-strict golden-path-e2e failure-injection-latency-check fedavg-scale-gate tpm-attestation-closure-check tpm-closure-summary ga-tag-ready-check release-performance-evidence openapi-spec capability-dashboard-matrix benchmark-gpu full-validation-fast full-validation-deep validation-trends validation-diff-summary workflow-pin-check fips-runtime-check fips-regression pqc-health tamper-evident-export tamper-evident-e2e-test testnet-gui-windows
 
 all: build verify
 
@@ -92,6 +92,12 @@ full-stack-3-nodes:
 full-stack-3-nodes-down:
 	@echo "🛑 Stopping full local stack..."
 	./scripts/launch_full_stack_3_nodes.sh --down
+
+testnet-gui-windows:
+	@echo "🪟 Building the Windows testnet GUI executable..."
+	mkdir -p dist/windows
+	bash -c 'source scripts/ensure_go_toolchain.sh && GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o dist/windows/testnet-gui.exe ./cmd/testnet-gui'
+	@echo "✅ Built dist/windows/testnet-gui.exe"
 
 sandbox-up:
 	@echo "🧪 Launching Mini-Mohawk sandbox..."

--- a/README.md
+++ b/README.md
@@ -479,6 +479,14 @@ PowerShell stop:
 ./scripts/launch_full_stack_3_nodes.ps1 -Down
 ```
 
+Windows GUI launcher:
+
+```bash
+make testnet-gui-windows
+```
+
+That target builds `dist/windows/testnet-gui.exe`, which opens a native Windows desktop window for the testnet stack and reuses the checked-in Windows launcher script for start/stop actions. It also exposes quick links to Grafana, Prometheus, and the orchestrator control plane.
+
 Grafana dashboard shortlist:
 
 * `Sovereign Mohawk | Start Here`

--- a/cmd/testnet-gui/main.go
+++ b/cmd/testnet-gui/main.go
@@ -1,0 +1,1100 @@
+//go:build !windows
+
+// Copyright 2026 Sovereign-Mohawk Core Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+const defaultListenAddr = "127.0.0.1:49281"
+
+var dashboardTemplate = template.Must(template.New("dashboard").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
+  <title>Sovereign Mohawk Testnet Control</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #07111f;
+      --bg-2: #0b1d30;
+      --panel: rgba(10, 21, 38, 0.86);
+      --panel-strong: rgba(13, 27, 49, 0.96);
+      --line: rgba(148, 163, 184, 0.18);
+      --text: #e5eefb;
+      --muted: #98a9c4;
+      --accent: #56e0c8;
+      --accent-2: #f7b955;
+      --good: #55d68a;
+      --warn: #f2c36d;
+      --bad: #f06a74;
+      --shadow: 0 22px 60px rgba(0, 0, 0, 0.38);
+      --radius: 22px;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: "Segoe UI Variable", "Segoe UI", "Trebuchet MS", sans-serif;
+      color: var(--text);
+      background:
+        radial-gradient(circle at top left, rgba(86, 224, 200, 0.18), transparent 30%),
+        radial-gradient(circle at 85% 15%, rgba(247, 185, 85, 0.17), transparent 26%),
+        linear-gradient(180deg, var(--bg) 0%, #091423 52%, #06101d 100%);
+      min-height: 100vh;
+    }
+
+    .shell {
+      max-width: 1360px;
+      margin: 0 auto;
+      padding: 28px;
+    }
+
+    .hero {
+      display: grid;
+      grid-template-columns: 1.4fr 1fr;
+      gap: 18px;
+      margin-bottom: 18px;
+    }
+
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(16px);
+    }
+
+    .hero-copy {
+      padding: 28px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .hero-copy::after {
+      content: "";
+      position: absolute;
+      inset: auto -120px -120px auto;
+      width: 280px;
+      height: 280px;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(86, 224, 200, 0.18), transparent 64%);
+      pointer-events: none;
+    }
+
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 8px 12px;
+      border-radius: 999px;
+      background: rgba(86, 224, 200, 0.12);
+      color: #bdf9ef;
+      border: 1px solid rgba(86, 224, 200, 0.18);
+      font-size: 12px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      margin-bottom: 18px;
+    }
+
+    .title {
+      margin: 0 0 10px;
+      font-size: clamp(32px, 4vw, 56px);
+      line-height: 1.02;
+      letter-spacing: -0.04em;
+    }
+
+    .gradient-text {
+      background: linear-gradient(135deg, var(--accent) 0%, #87a8ff 54%, var(--accent-2) 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .lede {
+      margin: 0;
+      max-width: 60ch;
+      color: var(--muted);
+      font-size: 16px;
+      line-height: 1.65;
+    }
+
+    .status-strip {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      margin-top: 18px;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      border-radius: 999px;
+      font-size: 13px;
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.04);
+    }
+
+    .dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--muted);
+      box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.04);
+    }
+
+    .dot.good { background: var(--good); }
+    .dot.warn { background: var(--warn); }
+    .dot.bad { background: var(--bad); }
+
+    .sidebar {
+      padding: 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .sidebar h2,
+    .section h2 {
+      margin: 0;
+      font-size: 18px;
+      letter-spacing: -0.02em;
+    }
+
+    .actions {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .button {
+      appearance: none;
+      border: none;
+      border-radius: 16px;
+      padding: 14px 16px;
+      color: #08111d;
+      font-weight: 700;
+      font-size: 14px;
+      cursor: pointer;
+      background: linear-gradient(135deg, var(--accent) 0%, #91fff0 100%);
+      box-shadow: 0 14px 28px rgba(86, 224, 200, 0.16);
+      transition: transform 140ms ease, box-shadow 140ms ease, opacity 140ms ease;
+      text-decoration: none;
+      text-align: center;
+    }
+
+    .button.secondary {
+      color: var(--text);
+      background: linear-gradient(135deg, rgba(123, 143, 173, 0.18) 0%, rgba(86, 224, 200, 0.14) 100%);
+      border: 1px solid var(--line);
+      box-shadow: none;
+    }
+
+    .button.critical {
+      color: #fff;
+      background: linear-gradient(135deg, #e96a73 0%, #f7b955 140%);
+      box-shadow: 0 14px 28px rgba(233, 106, 115, 0.16);
+    }
+
+    .button:hover { transform: translateY(-1px); }
+    .button:disabled { opacity: 0.55; cursor: not-allowed; transform: none; }
+
+    .section {
+      margin-top: 18px;
+      display: grid;
+      grid-template-columns: 1.25fr 0.75fr;
+      gap: 18px;
+    }
+
+    .services,
+    .activity {
+      padding: 22px;
+    }
+
+    .grid-list {
+      margin-top: 16px;
+      display: grid;
+      gap: 12px;
+    }
+
+    .service-row {
+      padding: 14px 16px;
+      border-radius: 16px;
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.03);
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+      align-items: center;
+    }
+
+    .service-name { font-weight: 700; }
+    .service-desc { color: var(--muted); font-size: 13px; margin-top: 4px; }
+
+    .tag {
+      padding: 7px 10px;
+      border-radius: 999px;
+      font-size: 12px;
+      border: 1px solid var(--line);
+      white-space: nowrap;
+    }
+
+    .tag.good { background: rgba(85, 214, 138, 0.12); color: #b8f3ce; }
+    .tag.warn { background: rgba(242, 195, 109, 0.12); color: #ffe3a1; }
+    .tag.bad { background: rgba(240, 106, 116, 0.12); color: #ffb2b8; }
+    .tag.neutral { color: var(--muted); }
+
+    .stat-grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 14px;
+    }
+
+    .stat {
+      padding: 18px;
+      border-radius: 18px;
+      border: 1px solid var(--line);
+      background: var(--panel-strong);
+      min-height: 126px;
+    }
+
+    .stat-label {
+      color: var(--muted);
+      font-size: 12px;
+      letter-spacing: 0.09em;
+      text-transform: uppercase;
+      margin-bottom: 12px;
+    }
+
+    .stat-value {
+      font-size: 30px;
+      font-weight: 700;
+      letter-spacing: -0.03em;
+      margin-bottom: 8px;
+    }
+
+    .stat-subtle {
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.45;
+    }
+
+    .log {
+      background: rgba(0, 0, 0, 0.24);
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      padding: 16px;
+      min-height: 360px;
+      max-height: 640px;
+      overflow: auto;
+      font-family: Consolas, "Cascadia Mono", "SFMono-Regular", monospace;
+      font-size: 12px;
+      line-height: 1.6;
+      white-space: pre-wrap;
+    }
+
+    .footer-note {
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.5;
+    }
+
+    .error {
+      margin-top: 8px;
+      color: #ffbcc0;
+      font-size: 13px;
+      min-height: 20px;
+    }
+
+    @media (max-width: 1100px) {
+      .hero,
+      .section {
+        grid-template-columns: 1fr;
+      }
+
+      .stat-grid {
+        grid-template-columns: repeat(2, 1fr);
+      }
+    }
+
+    @media (max-width: 700px) {
+      .shell { padding: 16px; }
+      .actions,
+      .stat-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .service-row {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <section class="hero">
+      <article class="panel hero-copy">
+        <div class="eyebrow"><span class="dot" id="stackDot"></span><span id="stackState">Loading testnet status</span></div>
+        <h1 class="title">Sovereign <span class="gradient-text">Mohawk</span><br>Testnet Control</h1>
+        <p class="lede">
+          A Windows-first launcher and status console for the local genesis testnet stack. Start the stack, stop it cleanly,
+          and watch the Docker, Prometheus, Grafana, and node-agent footprint from one place.
+        </p>
+        <div class="status-strip" id="statusStrip"></div>
+      </article>
+
+      <aside class="panel sidebar">
+        <div>
+          <h2>Actions</h2>
+          <div class="footer-note">The launcher uses the checked-in PowerShell script on Windows and falls back to Bash if available.</div>
+        </div>
+        <div class="actions">
+          <button class="button" id="startFullStack">Start Full Stack</button>
+          <button class="button secondary" id="startGenesis">Start Genesis</button>
+          <button class="button critical" id="stopStack">Stop Stack</button>
+          <button class="button secondary" id="refreshNow">Refresh Status</button>
+        </div>
+        <div class="actions">
+          <a class="button secondary" href="/open/grafana" target="_blank" rel="noreferrer">Open Grafana</a>
+          <a class="button secondary" href="/open/prometheus" target="_blank" rel="noreferrer">Open Prometheus</a>
+          <a class="button secondary" href="/open/orchestrator" target="_blank" rel="noreferrer">Open Orchestrator</a>
+          <a class="button secondary" href="/open/readme" target="_blank" rel="noreferrer">Open README</a>
+        </div>
+        <div class="error" id="errorBox"></div>
+      </aside>
+    </section>
+
+    <section class="stat-grid" id="statsGrid"></section>
+
+    <section class="section">
+      <article class="panel services">
+        <h2>Service Map</h2>
+        <div class="grid-list" id="serviceList"></div>
+      </article>
+
+      <article class="panel activity">
+        <h2>Launcher Log</h2>
+        <div class="footer-note" id="commandSummary">No command running.</div>
+        <div class="log" id="logOutput"></div>
+      </article>
+    </section>
+  </main>
+
+  <script>
+    async function fetchStatus() {
+      const response = await fetch('/api/status', { cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error('status request failed: ' + response.status);
+      }
+      return await response.json();
+    }
+
+    function escapeHtml(value) {
+      return String(value)
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
+    }
+
+    function renderBadge(kind, text) {
+      return '<span class="pill"><span class="dot ' + kind + '"></span>' + escapeHtml(text) + '</span>';
+    }
+
+    function renderStat(stat) {
+      return '<article class="stat">' +
+        '<div class="stat-label">' + escapeHtml(stat.label) + '</div>' +
+        '<div class="stat-value">' + escapeHtml(stat.value) + '</div>' +
+        '<div class="stat-subtle">' + escapeHtml(stat.subtext) + '</div>' +
+        '</article>';
+    }
+
+    function serviceTagClass(status) {
+      if (status === 'healthy' || status === 'running' || status === 'online') return 'good';
+      if (status === 'starting' || status === 'partial') return 'warn';
+      if (status === 'stopped' || status === 'offline' || status === 'missing' || status === 'error') return 'bad';
+      return 'neutral';
+    }
+
+    function renderService(service) {
+      const tagClass = serviceTagClass(service.status);
+      const detail = service.detail ? '<div class="service-desc">' + escapeHtml(service.detail) + '</div>' : '';
+      return '<div class="service-row">' +
+        '<div>' +
+          '<div class="service-name">' + escapeHtml(service.name) + '</div>' +
+          detail +
+        '</div>' +
+        '<div class="tag ' + tagClass + '">' + escapeHtml(service.status) + '</div>' +
+      '</div>';
+    }
+
+    async function mutate(path) {
+      const response = await fetch(path, { method: 'POST' });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(payload.error || 'request failed: ' + response.status);
+      }
+      return payload;
+    }
+
+    function setError(message) {
+      document.getElementById('errorBox').textContent = message || '';
+    }
+
+    function setBusy(isBusy) {
+      ['startFullStack', 'startGenesis', 'stopStack', 'refreshNow'].forEach((id) => {
+        document.getElementById(id).disabled = isBusy;
+      });
+    }
+
+    function renderStatus(status) {
+      document.getElementById('stackState').textContent = status.stack_state;
+      const stackDot = document.getElementById('stackDot');
+      stackDot.className = 'dot ' + status.stack_state_kind;
+
+      document.getElementById('statusStrip').innerHTML = [
+        renderBadge(status.docker_ok ? 'good' : 'bad', status.docker_ok ? 'Docker ready' : 'Docker unavailable'),
+        renderBadge(status.runner.running ? 'warn' : 'good', status.runner.running ? ('Command: ' + status.runner.label) : 'Launcher idle'),
+        renderBadge(status.stack_state_kind, status.stack_state),
+        renderBadge('neutral', status.online_services + '/' + status.total_services + ' services online'),
+      ].join('');
+
+      document.getElementById('statsGrid').innerHTML = [
+        renderStat({ label: 'Stack health', value: status.stack_state, subtext: status.stack_summary }),
+        renderStat({ label: 'Docker', value: status.docker_ok ? 'Ready' : 'Blocked', subtext: status.docker_detail || 'Docker is the only hard dependency for the stack.' }),
+        renderStat({ label: 'Online services', value: status.online_services + '/' + status.total_services, subtext: 'Node agents online: ' + status.online_nodes + '/' + status.expected_nodes }),
+        renderStat({ label: 'Active shell', value: status.shell_label, subtext: status.repo_root }),
+      ].join('');
+
+      document.getElementById('serviceList').innerHTML = status.services.map(renderService).join('');
+
+      const commandSummary = document.getElementById('commandSummary');
+      if (status.runner.running) {
+        commandSummary.textContent = status.runner.label + ' started ' + status.runner.started_at + ' from ' + status.runner.command;
+      } else if (status.runner.finished_at) {
+        commandSummary.textContent = status.runner.label + ' finished ' + status.runner.finished_at + (status.runner.exit_error ? ': ' + status.runner.exit_error : '');
+      } else {
+        commandSummary.textContent = 'No command running.';
+      }
+
+      document.getElementById('logOutput').textContent = status.runner.output.join('\n');
+    }
+
+    async function refresh() {
+      setError('');
+      try {
+        const status = await fetchStatus();
+        renderStatus(status);
+      } catch (err) {
+        setError(err.message || String(err));
+      }
+    }
+
+    async function action(path) {
+      setError('');
+      setBusy(true);
+      try {
+        await mutate(path);
+      } catch (err) {
+        setError(err.message || String(err));
+      } finally {
+        await refresh();
+        setBusy(false);
+      }
+    }
+
+    document.getElementById('startFullStack').addEventListener('click', () => action('/api/start/full-stack'));
+    document.getElementById('startGenesis').addEventListener('click', () => action('/api/start/genesis'));
+    document.getElementById('stopStack').addEventListener('click', () => action('/api/stop'));
+    document.getElementById('refreshNow').addEventListener('click', refresh);
+
+    refresh();
+    setInterval(refresh, 3000);
+  </script>
+</body>
+</html>`))
+
+type serviceStatus struct {
+	Name     string `json:"name"`
+	Endpoint string `json:"endpoint"`
+	Status   string `json:"status"`
+	Detail   string `json:"detail,omitempty"`
+}
+
+type runnerSnapshot struct {
+	Running    bool     `json:"running"`
+	Label      string   `json:"label"`
+	Command    string   `json:"command"`
+	StartedAt  string   `json:"started_at,omitempty"`
+	FinishedAt string   `json:"finished_at,omitempty"`
+	ExitError  string   `json:"exit_error,omitempty"`
+	Output     []string `json:"output"`
+}
+
+type statusResponse struct {
+	Timestamp      time.Time       `json:"timestamp"`
+	RepoRoot       string          `json:"repo_root"`
+	ShellLabel     string          `json:"shell_label"`
+	DockerOK       bool            `json:"docker_ok"`
+	DockerDetail   string          `json:"docker_detail,omitempty"`
+	StackState     string          `json:"stack_state"`
+	StackStateKind string          `json:"stack_state_kind"`
+	StackSummary   string          `json:"stack_summary"`
+	TotalServices  int             `json:"total_services"`
+	OnlineServices int             `json:"online_services"`
+	ExpectedNodes  int             `json:"expected_nodes"`
+	OnlineNodes    int             `json:"online_nodes"`
+	Runner         runnerSnapshot  `json:"runner"`
+	Services       []serviceStatus `json:"services"`
+}
+
+type launcher struct {
+	repoRoot string
+	runner   *commandRunner
+}
+
+type commandRunner struct {
+	mu         sync.Mutex
+	running    bool
+	label      string
+	command    string
+	startedAt  time.Time
+	finishedAt time.Time
+	exitError  string
+	buffer     capturedOutput
+}
+
+type capturedOutput struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (c *capturedOutput) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.Write(p)
+}
+
+func (c *capturedOutput) Lines(limit int) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	text := strings.ReplaceAll(c.buf.String(), "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	parts := strings.Split(text, "\n")
+	trimmed := make([]string, 0, len(parts))
+	for _, part := range parts {
+		line := strings.TrimSpace(part)
+		if line != "" {
+			trimmed = append(trimmed, line)
+		}
+	}
+	if len(trimmed) > limit {
+		trimmed = trimmed[len(trimmed)-limit:]
+	}
+	return trimmed
+}
+
+func (r *commandRunner) snapshot() runnerSnapshot {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	snapshot := runnerSnapshot{
+		Running:   r.running,
+		Label:     r.label,
+		Command:   r.command,
+		Output:    r.buffer.Lines(100),
+		ExitError: r.exitError,
+	}
+	if !r.startedAt.IsZero() {
+		snapshot.StartedAt = r.startedAt.Format(time.RFC3339)
+	}
+	if !r.finishedAt.IsZero() {
+		snapshot.FinishedAt = r.finishedAt.Format(time.RFC3339)
+	}
+	return snapshot
+}
+
+func (r *commandRunner) run(dir, label, command string, args ...string) error {
+	r.mu.Lock()
+	if r.running {
+		r.mu.Unlock()
+		return errors.New("a launcher command is already running")
+	}
+	r.running = true
+	r.label = label
+	r.command = strings.Join(append([]string{command}, args...), " ")
+	r.startedAt = time.Now()
+	r.finishedAt = time.Time{}
+	r.exitError = ""
+	r.buffer = capturedOutput{}
+	r.mu.Unlock()
+
+	cmd := exec.Command(command, args...)
+	cmd.Stdout = &r.buffer
+	cmd.Stderr = &r.buffer
+	cmd.Dir = dir
+
+	if err := cmd.Start(); err != nil {
+		r.finish(label, command, err)
+		return err
+	}
+
+	go func() {
+		err := cmd.Wait()
+		if err != nil {
+			r.finish(label, command, err)
+			return
+		}
+		r.finish(label, command, nil)
+	}()
+
+	return nil
+}
+
+func (r *commandRunner) finish(label, command string, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.running = false
+	r.label = label
+	r.command = command
+	r.finishedAt = time.Now()
+	if err != nil {
+		r.exitError = err.Error()
+	} else {
+		r.exitError = ""
+	}
+}
+
+func main() {
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	addr := os.Getenv("MOHAWK_TESTNET_GUI_ADDR")
+	if addr == "" {
+		addr = defaultListenAddr
+	}
+
+	app := &launcher{
+		repoRoot: repoRoot,
+		runner:   &commandRunner{},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", app.handleIndex)
+	mux.HandleFunc("/api/status", app.handleStatus)
+	mux.HandleFunc("/api/start/full-stack", app.handleStartFullStack)
+	mux.HandleFunc("/api/start/genesis", app.handleStartGenesis)
+	mux.HandleFunc("/api/stop", app.handleStop)
+	mux.HandleFunc("/open/", app.handleOpen)
+
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	url := "http://" + listener.Addr().String()
+	log.Printf("testnet GUI listening on %s", url)
+
+	go func() {
+		if os.Getenv("MOHAWK_TESTNET_GUI_NO_BROWSER") == "1" {
+			return
+		}
+		if err := openBrowser(url); err != nil {
+			log.Printf("browser launch skipped: %v", err)
+		}
+	}()
+
+	log.Fatal(server.Serve(listener))
+}
+
+func (a *launcher) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_ = dashboardTemplate.Execute(w, nil)
+}
+
+func (a *launcher) handleStatus(w http.ResponseWriter, r *http.Request) {
+	status := a.snapshotStatus()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(status)
+}
+
+func (a *launcher) handleStartFullStack(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := a.startFullStack(); err != nil {
+		writeJSONError(w, err, http.StatusBadRequest)
+		return
+	}
+	writeJSONOK(w)
+}
+
+func (a *launcher) handleStartGenesis(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := a.startGenesis(); err != nil {
+		writeJSONError(w, err, http.StatusBadRequest)
+		return
+	}
+	writeJSONOK(w)
+}
+
+func (a *launcher) handleStop(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := a.stopStack(); err != nil {
+		writeJSONError(w, err, http.StatusBadRequest)
+		return
+	}
+	writeJSONOK(w)
+}
+
+func (a *launcher) handleOpen(w http.ResponseWriter, r *http.Request) {
+	target := strings.TrimPrefix(r.URL.Path, "/open/")
+	url, ok := openTargetURL(target)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	http.Redirect(w, r, url, http.StatusFound)
+}
+
+func (a *launcher) snapshotStatus() statusResponse {
+	dockerOK, dockerDetail := checkDocker()
+	services, onlineServices, onlineNodes := a.collectServices()
+	stackState, stackKind, stackSummary := summarizeStack(services, dockerOK)
+
+	return statusResponse{
+		Timestamp:      time.Now().UTC(),
+		RepoRoot:       a.repoRoot,
+		ShellLabel:     a.shellLabel(),
+		DockerOK:       dockerOK,
+		DockerDetail:   dockerDetail,
+		StackState:     stackState,
+		StackStateKind: stackKind,
+		StackSummary:   stackSummary,
+		TotalServices:  len(services),
+		OnlineServices: onlineServices,
+		ExpectedNodes:  3,
+		OnlineNodes:    onlineNodes,
+		Runner:         a.runner.snapshot(),
+		Services:       services,
+	}
+}
+
+func (a *launcher) collectServices() ([]serviceStatus, int, int) {
+	services := []serviceStatus{
+		{Name: "orchestrator", Endpoint: "https://localhost:8080", Status: inspectContainer("orchestrator", "mTLS control plane")},
+		{Name: "shard-us-east", Endpoint: "compose", Status: inspectContainer("shard-us-east", "regional shard bootstrap")},
+		{Name: "node-agent-1", Endpoint: "compose", Status: inspectContainer("node-agent-1", "edge node")},
+		{Name: "node-agent-2", Endpoint: "compose", Status: inspectContainer("node-agent-2", "edge node")},
+		{Name: "node-agent-3", Endpoint: "compose", Status: inspectContainer("node-agent-3", "edge node")},
+		{Name: "federated-router", Endpoint: "http://localhost:3000", Status: inspectContainer("federated-router", "router and dashboard sidecar")},
+		{Name: "prometheus", Endpoint: "http://localhost:9090", Status: inspectHTTP("http://localhost:9090/-/healthy", "metrics query and scrape state")},
+		{Name: "grafana", Endpoint: "http://localhost:3000", Status: inspectHTTP("http://localhost:3000/api/health", "dashboard UI")},
+		{Name: "tpm-metrics", Endpoint: "http://localhost:9102/metrics", Status: inspectHTTP("http://localhost:9102/metrics", "attestation metrics export")},
+		{Name: "pyapi-metrics-exporter", Endpoint: "http://localhost:9103/metrics", Status: inspectContainer("pyapi-metrics-exporter", "Python SDK metrics export")},
+		{Name: "ipfs", Endpoint: "compose", Status: inspectContainer("ipfs", "artifact store")},
+	}
+
+	onlineServices := 0
+	onlineNodes := 0
+	for idx := range services {
+		if isServiceOnline(services[idx].Status) {
+			onlineServices++
+		}
+		if strings.HasPrefix(services[idx].Name, "node-agent-") && isServiceOnline(services[idx].Status) {
+			onlineNodes++
+		}
+	}
+
+	return services, onlineServices, onlineNodes
+}
+
+func (a *launcher) startFullStack() error {
+	if a.runner.snapshot().Running {
+		return errors.New("a launcher command is already running")
+	}
+	command, args, err := a.fullStackLauncher()
+	if err != nil {
+		return err
+	}
+	return a.runner.run(a.repoRoot, "full stack", command, args...)
+}
+
+func (a *launcher) startGenesis() error {
+	if a.runner.snapshot().Running {
+		return errors.New("a launcher command is already running")
+	}
+	command, args, err := a.genesisLauncher()
+	if err != nil {
+		return err
+	}
+	return a.runner.run(a.repoRoot, "genesis", command, args...)
+}
+
+func (a *launcher) stopStack() error {
+	if a.runner.snapshot().Running {
+		return errors.New("wait for the current launcher command to finish before stopping")
+	}
+	command, args, err := a.stopLauncher()
+	if err != nil {
+		return err
+	}
+	return a.runner.run(a.repoRoot, "stop stack", command, args...)
+}
+
+func (a *launcher) shellLabel() string {
+	if path, err := exec.LookPath("powershell.exe"); err == nil && path != "" {
+		return "PowerShell"
+	}
+	if path, err := exec.LookPath("pwsh"); err == nil && path != "" {
+		return "PowerShell Core"
+	}
+	if path, err := exec.LookPath("bash"); err == nil && path != "" {
+		return "Bash"
+	}
+	return "Unavailable"
+}
+
+func (a *launcher) fullStackLauncher() (string, []string, error) {
+	if path, err := exec.LookPath("powershell.exe"); err == nil && path != "" {
+		return path, []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-File", filepath.Join(a.repoRoot, "scripts", "launch_full_stack_3_nodes.ps1"), "-NoBuild"}, nil
+	}
+	if path, err := exec.LookPath("pwsh"); err == nil && path != "" {
+		return path, []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-File", filepath.Join(a.repoRoot, "scripts", "launch_full_stack_3_nodes.ps1"), "-NoBuild"}, nil
+	}
+	if path, err := exec.LookPath("bash"); err == nil && path != "" {
+		return path, []string{filepath.Join(a.repoRoot, "scripts", "launch_full_stack_3_nodes.sh"), "--no-build"}, nil
+	}
+	return "", nil, errors.New("no supported shell found: install PowerShell or Bash")
+}
+
+func (a *launcher) genesisLauncher() (string, []string, error) {
+	if path, err := exec.LookPath("bash"); err == nil && path != "" {
+		return path, []string{filepath.Join(a.repoRoot, "genesis-launch.sh"), "--all-nodes"}, nil
+	}
+	return "", nil, errors.New("genesis mode requires Bash to run genesis-launch.sh")
+}
+
+func (a *launcher) stopLauncher() (string, []string, error) {
+	if path, err := exec.LookPath("powershell.exe"); err == nil && path != "" {
+		return path, []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-File", filepath.Join(a.repoRoot, "scripts", "launch_full_stack_3_nodes.ps1"), "-Down"}, nil
+	}
+	if path, err := exec.LookPath("pwsh"); err == nil && path != "" {
+		return path, []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-File", filepath.Join(a.repoRoot, "scripts", "launch_full_stack_3_nodes.ps1"), "-Down"}, nil
+	}
+	if path, err := exec.LookPath("bash"); err == nil && path != "" {
+		return path, []string{filepath.Join(a.repoRoot, "scripts", "launch_full_stack_3_nodes.sh"), "--down"}, nil
+	}
+	return "", nil, errors.New("no supported shell found: install PowerShell or Bash")
+}
+
+func checkDocker() (bool, string) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		return false, "docker is not installed"
+	}
+	cmd := exec.Command("docker", "info")
+	if err := cmd.Run(); err != nil {
+		return false, "docker daemon is not reachable"
+	}
+	return true, "docker daemon is reachable"
+}
+
+func inspectContainer(name, detail string) string {
+	if _, err := exec.LookPath("docker"); err != nil {
+		return "offline"
+	}
+	cmd := exec.Command("docker", "inspect", "-f", "{{.State.Status}}{{if .State.Health}}/{{.State.Health.Status}}{{end}}", name)
+	output, err := cmd.Output()
+	if err != nil {
+		return "missing"
+	}
+	state := strings.TrimSpace(string(output))
+	if state == "" {
+		return "unknown"
+	}
+	if strings.Contains(state, "running/healthy") || strings.EqualFold(state, "healthy") {
+		_ = detail
+		return "healthy"
+	}
+	if strings.HasPrefix(state, "running") {
+		return "running"
+	}
+	if strings.Contains(state, "exited") {
+		return "stopped"
+	}
+	return state
+}
+
+func inspectHTTP(url, detail string) string {
+	client := http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return "offline"
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return "healthy"
+	}
+	_ = detail
+	return fmt.Sprintf("http %d", resp.StatusCode)
+}
+
+func summarizeStack(services []serviceStatus, dockerOK bool) (string, string, string) {
+	if !dockerOK {
+		return "Offline", "bad", "Docker is unavailable, so the testnet cannot be launched or inspected."
+	}
+	online := 0
+	for _, service := range services {
+		if isServiceOnline(service.Status) {
+			online++
+		}
+	}
+	if online == len(services) {
+		return "Online", "good", "Every tracked testnet service is reporting a live status."
+	}
+	if online >= 4 {
+		return "Partial", "warn", "The stack is partially online. A few services may still be starting or stopped."
+	}
+	return "Stopped", "bad", "The stack is not currently visible on the local Docker host."
+}
+
+func isServiceOnline(status string) bool {
+	return status == "healthy" || status == "running"
+}
+
+func findRepoRoot() (string, error) {
+	if root, ok := probeRepoRoot(mustExecutableDir()); ok {
+		return root, nil
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		if root, ok := probeRepoRoot(cwd); ok {
+			return root, nil
+		}
+	}
+	return "", errors.New("unable to locate the repository root")
+}
+
+func mustExecutableDir() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return "."
+	}
+	return filepath.Dir(exe)
+}
+
+func probeRepoRoot(start string) (string, bool) {
+	current := start
+	for {
+		if current == "" || current == "." || current == string(filepath.Separator) {
+			break
+		}
+		if fileExists(filepath.Join(current, "go.mod")) && fileExists(filepath.Join(current, "scripts", "launch_full_stack_3_nodes.ps1")) {
+			return current, true
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+	return "", false
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func openBrowser(url string) error {
+	switch runtime.GOOS {
+	case "linux":
+		if path, err := exec.LookPath("xdg-open"); err == nil && path != "" {
+			return exec.Command(path, url).Start()
+		}
+	case "darwin":
+		if path, err := exec.LookPath("open"); err == nil && path != "" {
+			return exec.Command(path, url).Start()
+		}
+	}
+	return errors.New("browser launch is not available")
+}
+
+func writeJSONOK(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+}
+
+func writeJSONError(w http.ResponseWriter, err error, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": err.Error()})
+}
+
+func openTargetURL(target string) (string, bool) {
+	switch target {
+	case "grafana":
+		return "http://localhost:3000", true
+	case "prometheus":
+		return "http://localhost:9090", true
+	case "orchestrator":
+		return "https://localhost:8080", true
+	case "readme":
+		return "https://github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/blob/main/README.md", true
+	default:
+		return "", false
+	}
+}

--- a/cmd/testnet-gui/main.go
+++ b/cmd/testnet-gui/main.go
@@ -1037,11 +1037,7 @@ func mustExecutableDir() string {
 }
 
 func probeRepoRoot(start string) (string, bool) {
-	current := start
-	for {
-		if current == "" || current == "." || current == string(filepath.Separator) {
-			break
-		}
+	for current := start; current != "" && current != "." && current != string(filepath.Separator); {
 		if fileExists(filepath.Join(current, "go.mod")) && fileExists(filepath.Join(current, "scripts", "launch_full_stack_3_nodes.ps1")) {
 			return current, true
 		}

--- a/cmd/testnet-gui/main_windows.go
+++ b/cmd/testnet-gui/main_windows.go
@@ -1,0 +1,991 @@
+//go:build windows
+
+// Copyright 2026 Sovereign-Mohawk Core Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+const (
+	windowClassName = "SovereignMohawkTestnetControlWindow"
+	windowTitle     = "Sovereign Mohawk Testnet Control"
+	timerRefreshID  = 1
+
+	idStatusLabel      = 1001
+	idStatusEdit       = 1002
+	idStartFullStack   = 2001
+	idStartGenesis     = 2002
+	idStopStack        = 2003
+	idRefreshStatus    = 2004
+	idOpenGrafana      = 2005
+	idOpenPrometheus   = 2006
+	idOpenOrchestrator = 2007
+	idOpenReadme       = 2008
+
+	wsOverlappedWindow = 0x00CF0000
+	wsVisible          = 0x10000000
+	wsChild            = 0x40000000
+	wsTabstop          = 0x00010000
+	wsBorder           = 0x00800000
+	wsVScroll          = 0x00200000
+	wsDisabled         = 0x08000000
+
+	swShow = 5
+
+	wmCreate  = 0x0001
+	wmDestroy = 0x0002
+	wmSize    = 0x0005
+	wmCommand = 0x0111
+	wmTimer   = 0x0113
+
+	bnClicked = 0
+
+	esMultiline   = 0x0004
+	esAutovScroll = 0x0040
+	esReadOnly    = 0x0800
+	esWantReturn  = 0x1000
+	esNoHideSel   = 0x0100
+
+	wsExClientEdge = 0x00000200
+	colorWindow    = 5
+)
+
+var (
+	user32   = syscall.NewLazyDLL("user32.dll")
+	kernel32 = syscall.NewLazyDLL("kernel32.dll")
+	shell32  = syscall.NewLazyDLL("shell32.dll")
+
+	procDefWindowProcW   = user32.NewProc("DefWindowProcW")
+	procRegisterClassExW = user32.NewProc("RegisterClassExW")
+	procCreateWindowExW  = user32.NewProc("CreateWindowExW")
+	procShowWindow       = user32.NewProc("ShowWindow")
+	procUpdateWindow     = user32.NewProc("UpdateWindow")
+	procGetMessageW      = user32.NewProc("GetMessageW")
+	procTranslateMessage = user32.NewProc("TranslateMessage")
+	procDispatchMessageW = user32.NewProc("DispatchMessageW")
+	procPostQuitMessage  = user32.NewProc("PostQuitMessage")
+	procSetWindowTextW   = user32.NewProc("SetWindowTextW")
+	procMoveWindow       = user32.NewProc("MoveWindow")
+	procSetTimer         = user32.NewProc("SetTimer")
+	procKillTimer        = user32.NewProc("KillTimer")
+	procGetClientRect    = user32.NewProc("GetClientRect")
+	procEnableWindow     = user32.NewProc("EnableWindow")
+	procLoadCursorW      = user32.NewProc("LoadCursorW")
+	procGetSystemMetrics = user32.NewProc("GetSystemMetrics")
+	procShellExecuteW    = shell32.NewProc("ShellExecuteW")
+	procGetModuleHandleW = kernel32.NewProc("GetModuleHandleW")
+)
+
+type desktopApp struct {
+	launcher   *launcher
+	hwnd       syscall.Handle
+	statusEdit syscall.Handle
+	statusLine syscall.Handle
+	buttons    map[int]syscall.Handle
+	lastError  string
+	mu         sync.Mutex
+}
+
+type launcher struct {
+	repoRoot string
+	runner   *commandRunner
+}
+
+type commandRunner struct {
+	mu         sync.Mutex
+	running    bool
+	label      string
+	command    string
+	startedAt  time.Time
+	finishedAt time.Time
+	exitError  string
+	buffer     capturedOutput
+}
+
+type capturedOutput struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+type serviceStatus struct {
+	Name     string `json:"name"`
+	Endpoint string `json:"endpoint"`
+	Status   string `json:"status"`
+	Detail   string `json:"detail,omitempty"`
+}
+
+type runnerSnapshot struct {
+	Running    bool     `json:"running"`
+	Label      string   `json:"label"`
+	Command    string   `json:"command"`
+	StartedAt  string   `json:"started_at,omitempty"`
+	FinishedAt string   `json:"finished_at,omitempty"`
+	ExitError  string   `json:"exit_error,omitempty"`
+	Output     []string `json:"output"`
+}
+
+type statusResponse struct {
+	Timestamp      time.Time       `json:"timestamp"`
+	RepoRoot       string          `json:"repo_root"`
+	ShellLabel     string          `json:"shell_label"`
+	DockerOK       bool            `json:"docker_ok"`
+	DockerDetail   string          `json:"docker_detail,omitempty"`
+	StackState     string          `json:"stack_state"`
+	StackStateKind string          `json:"stack_state_kind"`
+	StackSummary   string          `json:"stack_summary"`
+	TotalServices  int             `json:"total_services"`
+	OnlineServices int             `json:"online_services"`
+	ExpectedNodes  int             `json:"expected_nodes"`
+	OnlineNodes    int             `json:"online_nodes"`
+	Runner         runnerSnapshot  `json:"runner"`
+	Services       []serviceStatus `json:"services"`
+}
+
+var currentApp *desktopApp
+
+func main() {
+	runtime.LockOSThread()
+
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	currentApp = &desktopApp{
+		launcher: &launcher{
+			repoRoot: repoRoot,
+			runner:   &commandRunner{},
+		},
+		buttons: make(map[int]syscall.Handle),
+	}
+
+	if err := currentApp.run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (a *desktopApp) run() error {
+	hInstance := mustGetModuleHandle()
+	className := utf16Ptr(windowClassName)
+	wndProc := syscall.NewCallback(windowProc)
+	cursor := mustLoadCursor(32512)
+
+	wc := wndClassEx{
+		cbSize:        uint32(unsafe.Sizeof(wndClassEx{})),
+		style:         0,
+		lpfnWndProc:   wndProc,
+		cbClsExtra:    0,
+		cbWndExtra:    0,
+		hInstance:     hInstance,
+		hIcon:         0,
+		hCursor:       cursor,
+		hbrBackground: syscall.Handle(colorWindow + 1),
+		lpszMenuName:  nil,
+		lpszClassName: className,
+		hIconSm:       0,
+	}
+
+	if r, _, err := procRegisterClassExW.Call(uintptr(unsafe.Pointer(&wc))); r == 0 {
+		return err
+	}
+
+	hwnd, _, err := procCreateWindowExW.Call(
+		0,
+		uintptr(unsafe.Pointer(className)),
+		uintptr(unsafe.Pointer(utf16Ptr(windowTitle))),
+		uintptr(wsOverlappedWindow|wsVisible),
+		uintptr(int32(120)),
+		uintptr(int32(120)),
+		uintptr(int32(1260)),
+		uintptr(int32(860)),
+		0,
+		0,
+		uintptr(hInstance),
+		0,
+	)
+	if hwnd == 0 {
+		return err
+	}
+
+	a.hwnd = syscall.Handle(hwnd)
+	procShowWindow.Call(hwnd, swShow)
+	procUpdateWindow.Call(hwnd)
+
+	var msg msg
+	for {
+		r, _, _ := procGetMessageW.Call(uintptr(unsafe.Pointer(&msg)), 0, 0, 0)
+		if int32(r) <= 0 {
+			break
+		}
+		procTranslateMessage.Call(uintptr(unsafe.Pointer(&msg)))
+		procDispatchMessageW.Call(uintptr(unsafe.Pointer(&msg)))
+	}
+
+	return nil
+}
+
+func windowProc(hwnd uintptr, msg uint32, wParam, lParam uintptr) uintptr {
+	app := currentApp
+	if app == nil {
+		ret, _, _ := procDefWindowProcW.Call(hwnd, uintptr(msg), wParam, lParam)
+		return ret
+	}
+
+	switch msg {
+	case wmCreate:
+		app.hwnd = syscall.Handle(hwnd)
+		app.createControls()
+		app.refreshUI()
+		procSetTimer.Call(hwnd, timerRefreshID, 3000, 0)
+		return 0
+	case wmSize:
+		app.layoutControls()
+		return 0
+	case wmCommand:
+		id := int(uint16(wParam & 0xffff))
+		code := int(uint16((wParam >> 16) & 0xffff))
+		if code == bnClicked {
+			app.handleCommand(id)
+		}
+		return 0
+	case wmTimer:
+		if int(wParam) == timerRefreshID {
+			app.refreshUI()
+		}
+		return 0
+	case wmDestroy:
+		procKillTimer.Call(hwnd, timerRefreshID)
+		procPostQuitMessage.Call(0)
+		return 0
+	default:
+		ret, _, _ := procDefWindowProcW.Call(hwnd, uintptr(msg), wParam, lParam)
+		return ret
+	}
+}
+
+func (a *desktopApp) createControls() {
+	a.statusLine = a.createStatic(utf16Ptr("Initializing native testnet window..."), 16, 14, 1180, 22)
+	a.statusEdit = a.createEdit(16, 150, 1180, 640)
+
+	buttons := []struct {
+		id    int
+		label string
+	}{
+		{idStartFullStack, "Start Full Stack"},
+		{idStartGenesis, "Start Genesis"},
+		{idStopStack, "Stop Stack"},
+		{idRefreshStatus, "Refresh"},
+		{idOpenGrafana, "Open Grafana"},
+		{idOpenPrometheus, "Open Prometheus"},
+		{idOpenOrchestrator, "Open Orchestrator"},
+		{idOpenReadme, "Open README"},
+	}
+
+	for _, button := range buttons {
+		a.buttons[button.id] = a.createButton(button.id, utf16Ptr(button.label), 0, 0, 120, 28)
+	}
+
+	a.layoutControls()
+}
+
+func (a *desktopApp) layoutControls() {
+	if a.hwnd == 0 {
+		return
+	}
+	var rc rect
+	procGetClientRect.Call(uintptr(a.hwnd), uintptr(unsafe.Pointer(&rc)))
+	width := int(rc.Right - rc.Left)
+	height := int(rc.Bottom - rc.Top)
+	margin := 16
+	gap := 8
+	buttonHeight := 30
+	buttonWidth := (width - margin*2 - gap*3) / 4
+	if buttonWidth < 120 {
+		buttonWidth = 120
+	}
+	row1Y := 54
+	row2Y := row1Y + buttonHeight + gap
+	editY := row2Y + buttonHeight + 16
+	editHeight := height - editY - margin
+	if editHeight < 180 {
+		editHeight = 180
+	}
+
+	moveWindow(a.statusLine, margin, 14, width-margin*2, 22)
+
+	buttonOrder := []int{idStartFullStack, idStartGenesis, idStopStack, idRefreshStatus, idOpenGrafana, idOpenPrometheus, idOpenOrchestrator, idOpenReadme}
+	for i, id := range buttonOrder {
+		handle := a.buttons[id]
+		if handle == 0 {
+			continue
+		}
+		row := 0
+		col := i
+		if i >= 4 {
+			row = 1
+			col = i - 4
+		}
+		x := margin + col*(buttonWidth+gap)
+		y := row1Y + row*(buttonHeight+gap)
+		moveWindow(handle, x, y, buttonWidth, buttonHeight)
+	}
+
+	moveWindow(a.statusEdit, margin, editY, width-margin*2, editHeight)
+}
+
+func (a *desktopApp) createStatic(text *uint16, x, y, width, height int) syscall.Handle {
+	hwnd, _, _ := procCreateWindowExW.Call(
+		0,
+		uintptr(unsafe.Pointer(utf16Ptr("STATIC"))),
+		uintptr(unsafe.Pointer(text)),
+		uintptr(wsChild|wsVisible),
+		uintptr(int32(x)),
+		uintptr(int32(y)),
+		uintptr(int32(width)),
+		uintptr(int32(height)),
+		uintptr(a.hwnd),
+		0,
+		uintptr(mustGetModuleHandle()),
+		0,
+	)
+	return syscall.Handle(hwnd)
+}
+
+func (a *desktopApp) createButton(id int, text *uint16, x, y, width, height int) syscall.Handle {
+	hwnd, _, _ := procCreateWindowExW.Call(
+		0,
+		uintptr(unsafe.Pointer(utf16Ptr("BUTTON"))),
+		uintptr(unsafe.Pointer(text)),
+		uintptr(wsChild|wsVisible|wsTabstop),
+		uintptr(int32(x)),
+		uintptr(int32(y)),
+		uintptr(int32(width)),
+		uintptr(int32(height)),
+		uintptr(a.hwnd),
+		uintptr(syscall.Handle(id)),
+		uintptr(mustGetModuleHandle()),
+		0,
+	)
+	return syscall.Handle(hwnd)
+}
+
+func (a *desktopApp) createEdit(x, y, width, height int) syscall.Handle {
+	style := wsChild | wsVisible | wsBorder | wsVScroll | esMultiline | esAutovScroll | esReadOnly | esWantReturn | esNoHideSel
+	exStyle := wsExClientEdge
+	hwnd, _, _ := procCreateWindowExW.Call(
+		uintptr(exStyle),
+		uintptr(unsafe.Pointer(utf16Ptr("EDIT"))),
+		uintptr(unsafe.Pointer(utf16Ptr(""))),
+		uintptr(style),
+		uintptr(int32(x)),
+		uintptr(int32(y)),
+		uintptr(int32(width)),
+		uintptr(int32(height)),
+		uintptr(a.hwnd),
+		uintptr(syscall.Handle(idStatusEdit)),
+		uintptr(mustGetModuleHandle()),
+		0,
+	)
+	return syscall.Handle(hwnd)
+}
+
+func (a *desktopApp) handleCommand(id int) {
+	switch id {
+	case idStartFullStack:
+		if err := a.launcher.startFullStack(); err != nil {
+			a.lastError = err.Error()
+		} else {
+			a.lastError = ""
+		}
+	case idStartGenesis:
+		if err := a.launcher.startGenesis(); err != nil {
+			a.lastError = err.Error()
+		} else {
+			a.lastError = ""
+		}
+	case idStopStack:
+		if err := a.launcher.stopStack(); err != nil {
+			a.lastError = err.Error()
+		} else {
+			a.lastError = ""
+		}
+	case idRefreshStatus:
+		// Keep the timer-driven refresh behavior but allow explicit refresh.
+		a.lastError = ""
+	case idOpenGrafana:
+		if err := openTarget("grafana"); err != nil {
+			a.lastError = err.Error()
+		}
+	case idOpenPrometheus:
+		if err := openTarget("prometheus"); err != nil {
+			a.lastError = err.Error()
+		}
+	case idOpenOrchestrator:
+		if err := openTarget("orchestrator"); err != nil {
+			a.lastError = err.Error()
+		}
+	case idOpenReadme:
+		if err := openTarget("readme"); err != nil {
+			a.lastError = err.Error()
+		}
+	}
+	a.refreshUI()
+}
+
+func (a *desktopApp) refreshUI() {
+	status := a.launcher.snapshotStatus()
+	if a.lastError == "" {
+		statusText := fmt.Sprintf("Stack: %s | Docker: %s | Services: %d/%d | Nodes: %d/%d",
+			status.StackState,
+			dockerLabel(status.DockerOK),
+			status.OnlineServices,
+			status.TotalServices,
+			status.OnlineNodes,
+			status.ExpectedNodes,
+		)
+		setWindowText(a.statusLine, utf16Ptr(statusText))
+	} else {
+		setWindowText(a.statusLine, utf16Ptr("Error: "+a.lastError))
+	}
+
+	updateButtonsEnabled(a.buttons, !status.Runner.Running)
+	setWindowText(a.statusEdit, utf16Ptr(renderDesktopStatus(status, a.lastError)))
+}
+
+func renderDesktopStatus(status statusResponse, lastError string) string {
+	var b strings.Builder
+	b.WriteString("TESTNET STATUS\r\n")
+	b.WriteString(strings.Repeat("=", 72))
+	b.WriteString("\r\n")
+	fmt.Fprintf(&b, "State: %s\r\n", status.StackState)
+	fmt.Fprintf(&b, "Summary: %s\r\n", status.StackSummary)
+	fmt.Fprintf(&b, "Docker: %s (%s)\r\n", dockerLabel(status.DockerOK), status.DockerDetail)
+	fmt.Fprintf(&b, "Shell: %s\r\n", status.ShellLabel)
+	fmt.Fprintf(&b, "Services online: %d/%d\r\n", status.OnlineServices, status.TotalServices)
+	fmt.Fprintf(&b, "Node agents online: %d/%d\r\n", status.OnlineNodes, status.ExpectedNodes)
+	b.WriteString("\r\nSERVICE MAP\r\n")
+	for _, service := range status.Services {
+		fmt.Fprintf(&b, "- %-22s %-10s %s\r\n", service.Name, service.Status, service.Endpoint)
+		if service.Detail != "" {
+			fmt.Fprintf(&b, "  %s\r\n", service.Detail)
+		}
+	}
+	b.WriteString("\r\nCOMMAND RUNNER\r\n")
+	if status.Runner.Running {
+		fmt.Fprintf(&b, "Active: %s\r\n", status.Runner.Label)
+		fmt.Fprintf(&b, "Command: %s\r\n", status.Runner.Command)
+		fmt.Fprintf(&b, "Started: %s\r\n", status.Runner.StartedAt)
+	} else if status.Runner.FinishedAt != "" {
+		fmt.Fprintf(&b, "Last: %s\r\n", status.Runner.Label)
+		fmt.Fprintf(&b, "Finished: %s\r\n", status.Runner.FinishedAt)
+		if status.Runner.ExitError != "" {
+			fmt.Fprintf(&b, "Error: %s\r\n", status.Runner.ExitError)
+		}
+	} else {
+		b.WriteString("Idle\r\n")
+	}
+	if len(status.Runner.Output) > 0 {
+		b.WriteString("\r\nRecent output:\r\n")
+		for _, line := range status.Runner.Output {
+			b.WriteString(line)
+			b.WriteString("\r\n")
+		}
+	}
+	if lastError != "" {
+		b.WriteString("\r\nLast error: ")
+		b.WriteString(lastError)
+		b.WriteString("\r\n")
+	}
+	return b.String()
+}
+
+func updateButtonsEnabled(buttons map[int]syscall.Handle, enabled bool) {
+	for id, handle := range buttons {
+		if id == idRefreshStatus || id == idOpenGrafana || id == idOpenPrometheus || id == idOpenOrchestrator || id == idOpenReadme {
+			continue
+		}
+		procEnableWindow.Call(uintptr(handle), boolToUintptr(enabled))
+	}
+}
+
+func boolToUintptr(v bool) uintptr {
+	if v {
+		return 1
+	}
+	return 0
+}
+
+func setWindowText(hwnd syscall.Handle, text *uint16) {
+	procSetWindowTextW.Call(uintptr(hwnd), uintptr(unsafe.Pointer(text)))
+}
+
+func moveWindow(hwnd syscall.Handle, x, y, width, height int) {
+	procMoveWindow.Call(uintptr(hwnd), uintptr(int32(x)), uintptr(int32(y)), uintptr(int32(width)), uintptr(int32(height)), 1)
+}
+
+func openTarget(target string) error {
+	url, ok := openTargetURL(target)
+	if !ok {
+		return errors.New("unknown target: " + target)
+	}
+	r, _, err := procShellExecuteW.Call(
+		0,
+		uintptr(unsafe.Pointer(utf16Ptr("open"))),
+		uintptr(unsafe.Pointer(utf16Ptr(url))),
+		0,
+		0,
+		1,
+	)
+	if r <= 32 {
+		if err != syscall.Errno(0) {
+			return err
+		}
+		return errors.New("unable to open " + target)
+	}
+	return nil
+}
+
+func (a *launcher) snapshotStatus() statusResponse {
+	dockerOK, dockerDetail := checkDocker()
+	services, onlineServices, onlineNodes := a.collectServices()
+	stackState, stackKind, stackSummary := summarizeStack(services, dockerOK)
+
+	return statusResponse{
+		Timestamp:      time.Now().UTC(),
+		RepoRoot:       a.repoRoot,
+		ShellLabel:     a.shellLabel(),
+		DockerOK:       dockerOK,
+		DockerDetail:   dockerDetail,
+		StackState:     stackState,
+		StackStateKind: stackKind,
+		StackSummary:   stackSummary,
+		TotalServices:  len(services),
+		OnlineServices: onlineServices,
+		ExpectedNodes:  3,
+		OnlineNodes:    onlineNodes,
+		Runner:         a.runner.snapshot(),
+		Services:       services,
+	}
+}
+
+func (a *launcher) collectServices() ([]serviceStatus, int, int) {
+	services := []serviceStatus{
+		{Name: "orchestrator", Endpoint: "https://localhost:8080", Status: inspectContainer("orchestrator", "mTLS control plane")},
+		{Name: "shard-us-east", Endpoint: "compose", Status: inspectContainer("shard-us-east", "regional shard bootstrap")},
+		{Name: "node-agent-1", Endpoint: "compose", Status: inspectContainer("node-agent-1", "edge node")},
+		{Name: "node-agent-2", Endpoint: "compose", Status: inspectContainer("node-agent-2", "edge node")},
+		{Name: "node-agent-3", Endpoint: "compose", Status: inspectContainer("node-agent-3", "edge node")},
+		{Name: "federated-router", Endpoint: "http://localhost:3000", Status: inspectContainer("federated-router", "router and dashboard sidecar")},
+		{Name: "prometheus", Endpoint: "http://localhost:9090", Status: inspectHTTP("http://localhost:9090/-/healthy", "metrics query and scrape state")},
+		{Name: "grafana", Endpoint: "http://localhost:3000", Status: inspectHTTP("http://localhost:3000/api/health", "dashboard UI")},
+		{Name: "tpm-metrics", Endpoint: "http://localhost:9102/metrics", Status: inspectHTTP("http://localhost:9102/metrics", "attestation metrics export")},
+		{Name: "pyapi-metrics-exporter", Endpoint: "http://localhost:9103/metrics", Status: inspectContainer("pyapi-metrics-exporter", "Python SDK metrics export")},
+		{Name: "ipfs", Endpoint: "compose", Status: inspectContainer("ipfs", "artifact store")},
+	}
+
+	onlineServices := 0
+	onlineNodes := 0
+	for idx := range services {
+		if isServiceOnline(services[idx].Status) {
+			onlineServices++
+		}
+		if strings.HasPrefix(services[idx].Name, "node-agent-") && isServiceOnline(services[idx].Status) {
+			onlineNodes++
+		}
+	}
+
+	return services, onlineServices, onlineNodes
+}
+
+func (a *launcher) startFullStack() error {
+	if a.runner.snapshot().Running {
+		return errors.New("a launcher command is already running")
+	}
+	command, args, err := a.fullStackLauncher()
+	if err != nil {
+		return err
+	}
+	return a.runner.run(a.repoRoot, "full stack", command, args...)
+}
+
+func (a *launcher) startGenesis() error {
+	if a.runner.snapshot().Running {
+		return errors.New("a launcher command is already running")
+	}
+	command, args, err := a.genesisLauncher()
+	if err != nil {
+		return err
+	}
+	return a.runner.run(a.repoRoot, "genesis", command, args...)
+}
+
+func (a *launcher) stopStack() error {
+	if a.runner.snapshot().Running {
+		return errors.New("wait for the current launcher command to finish before stopping")
+	}
+	command, args, err := a.stopLauncher()
+	if err != nil {
+		return err
+	}
+	return a.runner.run(a.repoRoot, "stop stack", command, args...)
+}
+
+func (a *launcher) shellLabel() string {
+	if path, err := exec.LookPath("powershell.exe"); err == nil && path != "" {
+		return "PowerShell"
+	}
+	if path, err := exec.LookPath("pwsh"); err == nil && path != "" {
+		return "PowerShell Core"
+	}
+	if path, err := exec.LookPath("bash"); err == nil && path != "" {
+		return "Bash"
+	}
+	return "Unavailable"
+}
+
+func (a *launcher) fullStackLauncher() (string, []string, error) {
+	if path, err := exec.LookPath("powershell.exe"); err == nil && path != "" {
+		return path, []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-File", filepath.Join(a.repoRoot, "scripts", "launch_full_stack_3_nodes.ps1"), "-NoBuild"}, nil
+	}
+	if path, err := exec.LookPath("pwsh"); err == nil && path != "" {
+		return path, []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-File", filepath.Join(a.repoRoot, "scripts", "launch_full_stack_3_nodes.ps1"), "-NoBuild"}, nil
+	}
+	if path, err := exec.LookPath("bash"); err == nil && path != "" {
+		return path, []string{filepath.Join(a.repoRoot, "scripts", "launch_full_stack_3_nodes.sh"), "--no-build"}, nil
+	}
+	return "", nil, errors.New("no supported shell found: install PowerShell or Bash")
+}
+
+func (a *launcher) genesisLauncher() (string, []string, error) {
+	if path, err := exec.LookPath("bash"); err == nil && path != "" {
+		return path, []string{filepath.Join(a.repoRoot, "genesis-launch.sh"), "--all-nodes"}, nil
+	}
+	return "", nil, errors.New("genesis mode requires Bash to run genesis-launch.sh")
+}
+
+func (a *launcher) stopLauncher() (string, []string, error) {
+	if path, err := exec.LookPath("powershell.exe"); err == nil && path != "" {
+		return path, []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-File", filepath.Join(a.repoRoot, "scripts", "launch_full_stack_3_nodes.ps1"), "-Down"}, nil
+	}
+	if path, err := exec.LookPath("pwsh"); err == nil && path != "" {
+		return path, []string{"-NoProfile", "-ExecutionPolicy", "Bypass", "-File", filepath.Join(a.repoRoot, "scripts", "launch_full_stack_3_nodes.ps1"), "-Down"}, nil
+	}
+	if path, err := exec.LookPath("bash"); err == nil && path != "" {
+		return path, []string{filepath.Join(a.repoRoot, "scripts", "launch_full_stack_3_nodes.sh"), "--down"}, nil
+	}
+	return "", nil, errors.New("no supported shell found: install PowerShell or Bash")
+}
+
+func (r *commandRunner) snapshot() runnerSnapshot {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	snapshot := runnerSnapshot{
+		Running:   r.running,
+		Label:     r.label,
+		Command:   r.command,
+		Output:    r.buffer.Lines(100),
+		ExitError: r.exitError,
+	}
+	if !r.startedAt.IsZero() {
+		snapshot.StartedAt = r.startedAt.Format(time.RFC3339)
+	}
+	if !r.finishedAt.IsZero() {
+		snapshot.FinishedAt = r.finishedAt.Format(time.RFC3339)
+	}
+	return snapshot
+}
+
+func (r *commandRunner) run(dir, label, command string, args ...string) error {
+	r.mu.Lock()
+	if r.running {
+		r.mu.Unlock()
+		return errors.New("a launcher command is already running")
+	}
+	r.running = true
+	r.label = label
+	r.command = strings.Join(append([]string{command}, args...), " ")
+	r.startedAt = time.Now()
+	r.finishedAt = time.Time{}
+	r.exitError = ""
+	r.buffer = capturedOutput{}
+	r.mu.Unlock()
+
+	cmd := exec.Command(command, args...)
+	cmd.Stdout = &r.buffer
+	cmd.Stderr = &r.buffer
+	cmd.Dir = dir
+
+	if err := cmd.Start(); err != nil {
+		r.finish(label, command, err)
+		return err
+	}
+
+	go func() {
+		err := cmd.Wait()
+		if err != nil {
+			r.finish(label, command, err)
+			return
+		}
+		r.finish(label, command, nil)
+	}()
+
+	return nil
+}
+
+func (r *commandRunner) finish(label, command string, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.running = false
+	r.label = label
+	r.command = command
+	r.finishedAt = time.Now()
+	if err != nil {
+		r.exitError = err.Error()
+	} else {
+		r.exitError = ""
+	}
+}
+
+func (c *capturedOutput) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.Write(p)
+}
+
+func (c *capturedOutput) Lines(limit int) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	text := strings.ReplaceAll(c.buf.String(), "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	parts := strings.Split(text, "\n")
+	trimmed := make([]string, 0, len(parts))
+	for _, part := range parts {
+		line := strings.TrimSpace(part)
+		if line != "" {
+			trimmed = append(trimmed, line)
+		}
+	}
+	if len(trimmed) > limit {
+		trimmed = trimmed[len(trimmed)-limit:]
+	}
+	return trimmed
+}
+
+func checkDocker() (bool, string) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		return false, "docker is not installed"
+	}
+	cmd := exec.Command("docker", "info")
+	if err := cmd.Run(); err != nil {
+		return false, "docker daemon is not reachable"
+	}
+	return true, "docker daemon is reachable"
+}
+
+func inspectContainer(name, detail string) string {
+	if _, err := exec.LookPath("docker"); err != nil {
+		return "offline"
+	}
+	cmd := exec.Command("docker", "inspect", "-f", "{{.State.Status}}{{if .State.Health}}/{{.State.Health.Status}}{{end}}", name)
+	output, err := cmd.Output()
+	if err != nil {
+		return "missing"
+	}
+	state := strings.TrimSpace(string(output))
+	if state == "" {
+		return "unknown"
+	}
+	if strings.Contains(state, "running/healthy") || strings.EqualFold(state, "healthy") {
+		_ = detail
+		return "healthy"
+	}
+	if strings.HasPrefix(state, "running") {
+		return "running"
+	}
+	if strings.Contains(state, "exited") {
+		return "stopped"
+	}
+	return state
+}
+
+func inspectHTTP(url, detail string) string {
+	client := http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return "offline"
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return "healthy"
+	}
+	_ = detail
+	return fmt.Sprintf("http %d", resp.StatusCode)
+}
+
+func summarizeStack(services []serviceStatus, dockerOK bool) (string, string, string) {
+	if !dockerOK {
+		return "Offline", "bad", "Docker is unavailable, so the testnet cannot be launched or inspected."
+	}
+	online := 0
+	for _, service := range services {
+		if isServiceOnline(service.Status) {
+			online++
+		}
+	}
+	if online == len(services) {
+		return "Online", "good", "Every tracked testnet service is reporting a live status."
+	}
+	if online >= 4 {
+		return "Partial", "warn", "The stack is partially online. A few services may still be starting or stopped."
+	}
+	return "Stopped", "bad", "The stack is not currently visible on the local Docker host."
+}
+
+func isServiceOnline(status string) bool {
+	return status == "healthy" || status == "running"
+}
+
+func findRepoRoot() (string, error) {
+	if root, ok := probeRepoRoot(mustExecutableDir()); ok {
+		return root, nil
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		if root, ok := probeRepoRoot(cwd); ok {
+			return root, nil
+		}
+	}
+	return "", errors.New("unable to locate the repository root")
+}
+
+func mustExecutableDir() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return "."
+	}
+	return filepath.Dir(exe)
+}
+
+func probeRepoRoot(start string) (string, bool) {
+	current := start
+	for {
+		if current == "" || current == "." || current == string(filepath.Separator) {
+			break
+		}
+		if fileExists(filepath.Join(current, "go.mod")) && fileExists(filepath.Join(current, "scripts", "launch_full_stack_3_nodes.ps1")) {
+			return current, true
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+	return "", false
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func openTargetURL(target string) (string, bool) {
+	switch target {
+	case "grafana":
+		return "http://localhost:3000", true
+	case "prometheus":
+		return "http://localhost:9090", true
+	case "orchestrator":
+		return "https://localhost:8080", true
+	case "readme":
+		return "https://github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/blob/main/README.md", true
+	default:
+		return "", false
+	}
+}
+
+func dockerLabel(ok bool) string {
+	if ok {
+		return "Ready"
+	}
+	return "Blocked"
+}
+
+func utf16Ptr(value string) *uint16 {
+	ptr, err := syscall.UTF16PtrFromString(value)
+	if err != nil {
+		return nil
+	}
+	return ptr
+}
+
+func mustGetModuleHandle() syscall.Handle {
+	h, _, _ := procGetModuleHandleW.Call(0)
+	return syscall.Handle(h)
+}
+
+func mustLoadCursor(id uintptr) syscall.Handle {
+	h, _, _ := procLoadCursorW.Call(0, id)
+	return syscall.Handle(h)
+}
+
+type wndClassEx struct {
+	cbSize        uint32
+	style         uint32
+	lpfnWndProc   uintptr
+	cbClsExtra    int32
+	cbWndExtra    int32
+	hInstance     syscall.Handle
+	hIcon         syscall.Handle
+	hCursor       syscall.Handle
+	hbrBackground syscall.Handle
+	lpszMenuName  *uint16
+	lpszClassName *uint16
+	hIconSm       syscall.Handle
+}
+
+type rect struct {
+	Left   int32
+	Top    int32
+	Right  int32
+	Bottom int32
+}
+
+type msg struct {
+	Hwnd    uintptr
+	Message uint32
+	WParam  uintptr
+	LParam  uintptr
+	Time    uint32
+	Pt      point
+}
+
+type point struct {
+	X int32
+	Y int32
+}


### PR DESCRIPTION
## Summary
This PR adds a Windows-focused native desktop launcher for local testnet operations and wires in a Windows executable build target.

## Changes
- Add Windows-only native Win32 desktop app entrypoint in `cmd/testnet-gui/main_windows.go`
- Add non-Windows implementation split in `cmd/testnet-gui/main.go` via build tags
- Add `make testnet-gui-windows` target in `Makefile` to build `dist/windows/testnet-gui.exe`
- Update README with Windows GUI launcher usage and behavior

## Why
This enables a true native Windows desktop workflow for starting/stopping and monitoring the testnet stack while preserving non-Windows behavior.

## Notes
- Branch: `feat/windows-native-testnet-gui`
- Base: `main`
- Build artifact is intentionally not committed.