### PR TITLE
Add Flower-compatible client integration plan

### DIFF
--- a/.github/workflows/flower-integration.yml
+++ b/.github/workflows/flower-integration.yml
@@ -1,0 +1,42 @@
+name: Flower Integration
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sdk/python/**'
+      - '.github/workflows/flower-integration.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'sdk/python/**'
+      - '.github/workflows/flower-integration.yml'
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  flower-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: '3.12'
+
+      - name: Install SDK and test dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -e ./sdk/python[dev,flower]
+
+      - name: Run Flower adapter tests
+        run: |
+          cd sdk/python
+          pytest -q tests/test_flower_client.py tests/test_client.py
+
+      - name: Run Flower smoke example
+        run: |
+          python3 sdk/python/examples/flower_mohawk_demo.py --ci

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -175,6 +175,7 @@ TPM production closure sign-off (2026-04-11):
 - [ ] Notebook pack refresh with end-to-end production scenarios
 - [ ] Fuzzing expansion for C bridge + serialization boundaries
 - [ ] Optional OpenTelemetry distributed tracing rollout
+- [ ] Flower-compatible client integration plan and example ports (see [docs/flower-integration.md](docs/flower-integration.md))
 
 ---
 

--- a/docs/flower-integration.md
+++ b/docs/flower-integration.md
@@ -1,4 +1,4 @@
-# Flower-Compatible Client Integration Plan
+# Flower-Compatible Client Integration
 
 ## Goal
 
@@ -7,69 +7,87 @@ Add Flower-compatible client-side training workflows to the Python SDK without m
 The intended architecture is:
 
 - Flower provides the familiar client-side `fit()` / `evaluate()` lifecycle and example training loops.
-- The Mohawk Python SDK owns local model handling, gradient compression, privacy accounting, and proof submission.
+- The Mohawk Python SDK owns local model handling, gradient compression, proof-envelope generation, and aggregation submission.
 - The Go node agent remains the authoritative layer for aggregation, hierarchy, and verification.
 
-This is a compatibility plan, not a promise that Flower examples run unchanged in production.
+This implementation is intentionally scoped: one adapter, one runnable smoke example, and tests that prove the integration remains usable without requiring Flower at import time.
 
-## Scope Corrections
+## Implemented Pieces
 
-The original draft assumed a few things that are not present in the repo yet:
+The repository now includes:
 
-- There is no existing Flower dependency in `sdk/python`.
-- There is no `MohawkFlowerClient` wrapper today.
-- `wasm-modules/flower_task` is a useful runtime integration point, but it is not a drop-in executor for every Flower example.
+- `sdk/python/mohawk/flower_client.py` with `MohawkFlowerClient`
+- `sdk/python/examples/flower_mohawk_demo.py` as a smoke-testable end-to-end example
+- `sdk/python/tests/test_flower_client.py` covering fallback behavior, Flower-style inheritance, and round submission
+- `sdk/python/pyproject.toml` optional `flower` extra
+- `.github/workflows/flower-integration.yml` for CI smoke coverage
 
-The first implementation should therefore focus on a thin adapter and a small number of example ports, then expand after the interface is stable.
+`wasm-modules/flower_task` remains available as a future execution target, but the client-side integration no longer depends on it.
 
-## Phase 1: Environment And Packaging
+## Runtime Shape
 
-1. Add Flower as an optional Python dependency in `sdk/python/pyproject.toml`.
-2. Keep the base install light; make Flower and ML frameworks opt-in extras.
-3. Document the expected dev setup in `sdk/python/README.md`.
-4. Verify the Python SDK can still be installed with `pip install -e .[dev]` without Flower.
+1. The Flower adapter accepts local training and evaluation callables.
+2. The adapter flattens updated model parameters for Mohawk compression and aggregation.
+3. The adapter emits a deterministic proof manifest that can be extended to a real ZK proof hook later.
+4. The adapter keeps the base SDK usable when Flower is not installed.
 
-Suggested extras:
+## Packaging
+
+Suggested install extras:
 
 - `flower`
 - `torch` or framework-specific extras as needed for examples
 
-## Phase 2: Client Adapter
+Use the optional Flower extra when you want to plug the adapter into Flower simulators or examples:
+
+```bash
+cd sdk/python
+pip install -e .[flower]
+```
+
+## Adapter
 
 Add a small adapter layer in the Python SDK that bridges Flower client callbacks to Mohawk operations.
 
 Recommended shape:
 
-- Create a new `MohawkFlowerClient` wrapper in `sdk/python/mohawk/`.
-- Have it accept a `MohawkNode` or similar SDK client object.
-- Keep model training logic outside the wrapper so example code can supply PyTorch, TensorFlow, JAX, or sklearn loops.
-- Convert Flower parameters to the SDK's gradient/update format, then hand the result to the Go runtime for aggregation and proof workflows.
+- `MohawkFlowerClient` accepts a `MohawkNode` plus `train_fn` and `evaluate_fn` callables.
+- The wrapper keeps the local model logic outside the SDK so Flower examples can reuse their own training loops.
+- The wrapper compresses updated parameters through Mohawk, emits a proof manifest, and submits the gradient update to the Go-backed aggregator.
+- The wrapper works even when Flower is absent by using a local fallback base class with the same method shape.
 
 Important design rule:
 
 - Flower should not become the source of truth for verification or aggregation policy.
 - The wrapper should call Mohawk hooks after local training and before remote submission.
 
-## Phase 3: Example Ports
+## Example
 
-Create a small example folder under `sdk/python/examples/` for Flower-compatible demos.
+`sdk/python/examples/flower_mohawk_demo.py` is the first runnable demo.
 
-Start with one minimal training example and one larger framework example.
+It demonstrates:
 
-Good first candidates:
+- local training callback execution
+- Mohawk compression and aggregation submission
+- proof-manifest generation
+- evaluation callback execution
 
-- PyTorch quickstart-style client
-- A lightweight evaluation-only client
-- A demo that exercises compression and proof submission
+Run it with:
 
-Each example should show:
+```bash
+python sdk/python/examples/flower_mohawk_demo.py --ci
+```
 
-- local training loop
-- parameter round-trip through Flower callbacks
-- Mohawk compression and update submission
-- a simple simulator entry point
+## CI And Tests
 
-## Phase 4: Optional Strategy Bridge
+Current validation includes:
+
+- `pytest sdk/python/tests/test_flower_client.py`
+- `pytest sdk/python/tests/test_client.py tests/test_flower_client.py`
+- the smoke example in CI mode
+- the new Flower integration workflow on `push` and `pull_request`
+
+## Optional Strategy Bridge
 
 Keep Flower server strategies optional and non-blocking.
 
@@ -81,35 +99,14 @@ Recommended approach:
 
 This keeps the architecture aligned with the repository's current strength: Go-owned verification and aggregation.
 
-## Phase 5: Tests And CI
-
-Add tests that prove the compatibility layer behaves correctly before expanding the example set.
-
-Minimum test coverage:
-
-- adapter smoke test with mocked Flower parameters
-- serialization round-trip test for model updates
-- update submission test against a mocked Mohawk runtime
-- one end-to-end example test in `sdk/python/tests/`
-
-Suggested CI additions:
-
-- a lightweight workflow that installs the optional Flower extras
-- a smoke run for the example client
-- existing proof-verification checks reused where applicable
-
-## Out Of Scope For The First PR
+## Out Of Scope
 
 - claiming zero-code-change integration for all Flower examples
 - moving aggregation authority out of the Go runtime
 - adding every Flower framework at once
 - asserting WASM attestation is automatically available for all client code paths
+- replacing the Go verifier with a Python proof generator
 
-## Proposed First Delivery
+## Next Increment
 
-1. Add the documentation and roadmap pointer.
-2. Add the Python package extras needed for a Flower-compatible path.
-3. Add the adapter skeleton and one example.
-4. Add tests and a minimal CI smoke check.
-
-That sequence keeps the branch reviewable and gives a clear path from prototype to working integration.
+If this integration is expanded further, the next sensible step is a typed NumPy round-trip helper plus one real Flower example port, such as a quickstart PyTorch client.

--- a/docs/flower-integration.md
+++ b/docs/flower-integration.md
@@ -1,0 +1,115 @@
+# Flower-Compatible Client Integration Plan
+
+## Goal
+
+Add Flower-compatible client-side training workflows to the Python SDK without moving orchestration authority away from the Go runtime.
+
+The intended architecture is:
+
+- Flower provides the familiar client-side `fit()` / `evaluate()` lifecycle and example training loops.
+- The Mohawk Python SDK owns local model handling, gradient compression, privacy accounting, and proof submission.
+- The Go node agent remains the authoritative layer for aggregation, hierarchy, and verification.
+
+This is a compatibility plan, not a promise that Flower examples run unchanged in production.
+
+## Scope Corrections
+
+The original draft assumed a few things that are not present in the repo yet:
+
+- There is no existing Flower dependency in `sdk/python`.
+- There is no `MohawkFlowerClient` wrapper today.
+- `wasm-modules/flower_task` is a useful runtime integration point, but it is not a drop-in executor for every Flower example.
+
+The first implementation should therefore focus on a thin adapter and a small number of example ports, then expand after the interface is stable.
+
+## Phase 1: Environment And Packaging
+
+1. Add Flower as an optional Python dependency in `sdk/python/pyproject.toml`.
+2. Keep the base install light; make Flower and ML frameworks opt-in extras.
+3. Document the expected dev setup in `sdk/python/README.md`.
+4. Verify the Python SDK can still be installed with `pip install -e .[dev]` without Flower.
+
+Suggested extras:
+
+- `flower`
+- `torch` or framework-specific extras as needed for examples
+
+## Phase 2: Client Adapter
+
+Add a small adapter layer in the Python SDK that bridges Flower client callbacks to Mohawk operations.
+
+Recommended shape:
+
+- Create a new `MohawkFlowerClient` wrapper in `sdk/python/mohawk/`.
+- Have it accept a `MohawkNode` or similar SDK client object.
+- Keep model training logic outside the wrapper so example code can supply PyTorch, TensorFlow, JAX, or sklearn loops.
+- Convert Flower parameters to the SDK's gradient/update format, then hand the result to the Go runtime for aggregation and proof workflows.
+
+Important design rule:
+
+- Flower should not become the source of truth for verification or aggregation policy.
+- The wrapper should call Mohawk hooks after local training and before remote submission.
+
+## Phase 3: Example Ports
+
+Create a small example folder under `sdk/python/examples/` for Flower-compatible demos.
+
+Start with one minimal training example and one larger framework example.
+
+Good first candidates:
+
+- PyTorch quickstart-style client
+- A lightweight evaluation-only client
+- A demo that exercises compression and proof submission
+
+Each example should show:
+
+- local training loop
+- parameter round-trip through Flower callbacks
+- Mohawk compression and update submission
+- a simple simulator entry point
+
+## Phase 4: Optional Strategy Bridge
+
+Keep Flower server strategies optional and non-blocking.
+
+Recommended approach:
+
+- Default path: keep aggregation in Go and only adapt the client side.
+- Optional path: add a small Python bridge that forwards aggregates to the Go orchestrator over the existing SDK boundary.
+- Only port a Flower strategy to Go if a real usage case requires it.
+
+This keeps the architecture aligned with the repository's current strength: Go-owned verification and aggregation.
+
+## Phase 5: Tests And CI
+
+Add tests that prove the compatibility layer behaves correctly before expanding the example set.
+
+Minimum test coverage:
+
+- adapter smoke test with mocked Flower parameters
+- serialization round-trip test for model updates
+- update submission test against a mocked Mohawk runtime
+- one end-to-end example test in `sdk/python/tests/`
+
+Suggested CI additions:
+
+- a lightweight workflow that installs the optional Flower extras
+- a smoke run for the example client
+- existing proof-verification checks reused where applicable
+
+## Out Of Scope For The First PR
+
+- claiming zero-code-change integration for all Flower examples
+- moving aggregation authority out of the Go runtime
+- adding every Flower framework at once
+- asserting WASM attestation is automatically available for all client code paths
+
+## Proposed First Delivery
+
+1. Add the documentation and roadmap pointer.
+2. Add the Python package extras needed for a Flower-compatible path.
+3. Add the adapter skeleton and one example.
+4. Add tests and a minimal CI smoke check.
+
+That sequence keeps the branch reviewable and gives a clear path from prototype to working integration.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -59,6 +59,7 @@ pip install -e .[dev]
 
 # Optional extras
 pip install -e .[accelerator]
+pip install -e .[flower]
 ```
 
 ### Verifying Installation
@@ -175,6 +176,42 @@ with MohawkNode() as node:
     )
 
 print(hybrid_receipt.success)
+```
+
+### Flower-Compatible Client Wrapper
+
+The SDK includes a Flower-compatible adapter that lets you reuse Flower-style
+local training callbacks while keeping Mohawk responsible for compression,
+proof-envelope generation, and aggregation submission.
+
+```python
+from mohawk import MohawkFlowerClient, MohawkNode
+
+def train_step(parameters, config):
+    del config
+    updated = [[value + 0.25 for value in tensor] for tensor in parameters]
+    return updated, 32, {"loss": 0.125}
+
+
+client = MohawkFlowerClient(
+    MohawkNode(),
+    train_fn=train_step,
+    initial_parameters=[[0.0, 1.0], [2.0, 3.0]],
+    node_id="flower-client-001",
+)
+
+updated_parameters, num_examples, metrics = client.fit(
+    client.get_parameters({}),
+    {"server_round": 1, "mohawk_format": "fp16"},
+)
+```
+
+Install the optional Flower dependency when you want to plug this adapter into
+Flower examples or Flower's simulator:
+
+```bash
+cd sdk/python
+pip install -e .[flower]
 ```
 
 ### Utility Coin Operations

--- a/sdk/python/examples/flower_mohawk_demo.py
+++ b/sdk/python/examples/flower_mohawk_demo.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Smoke test for the Flower-compatible Mohawk adapter."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from mohawk import MohawkFlowerClient, MohawkNode
+
+
+def build_training_fn():
+    def _train(parameters, config):
+        del config
+        updated = []
+        for tensor in parameters:
+            if isinstance(tensor, list):
+                updated.append([value + 0.25 for value in tensor])
+            else:
+                updated.append(tensor + 0.25)
+        metrics = {"loss": 0.125, "accuracy": 0.95}
+        return updated, 32, metrics
+
+    return _train
+
+
+def build_evaluate_fn():
+    def _evaluate(parameters, config):
+        del parameters, config
+        return 0.125, 32, {"accuracy": 0.95}
+
+    return _evaluate
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ci", action="store_true", help="Emit machine-readable smoke output")
+    args = parser.parse_args()
+
+    client = MohawkFlowerClient(
+        MohawkNode(),
+        train_fn=build_training_fn(),
+        evaluate_fn=build_evaluate_fn(),
+        initial_parameters=[[0.0, 1.0], [2.0, 3.0]],
+        node_id="flower-demo-node",
+        submit_updates=True,
+    )
+
+    parameters = client.get_parameters({})
+    updated_parameters, num_examples, metrics = client.fit(
+        parameters,
+        {"server_round": 1, "mohawk_format": "fp16", "mohawk_max_norm": 1.0},
+    )
+    loss, eval_examples, eval_metrics = client.evaluate(updated_parameters, {})
+
+    payload = {
+        "node_id": client.node_id,
+        "num_examples": num_examples,
+        "loss": loss,
+        "eval_examples": eval_examples,
+        "fit_metrics": metrics,
+        "eval_metrics": eval_metrics,
+    }
+    if args.ci:
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        print("Flower-compatible Mohawk demo")
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/python/mohawk/__init__.py
+++ b/sdk/python/mohawk/__init__.py
@@ -32,6 +32,7 @@ from .high_level import (
     HybridProofCheck,
     HybridVerificationReceipt,
 )
+from .flower_client import FlowerTrainingReport, MohawkFlowerClient
 
 __version__ = "2.0.1.Alpha"
 __all__ = [
@@ -62,4 +63,6 @@ __all__ = [
     # High-level wrappers
     "HybridProofCheck",
     "HybridVerificationReceipt",
+    "FlowerTrainingReport",
+    "MohawkFlowerClient",
 ]

--- a/sdk/python/mohawk/flower_client.py
+++ b/sdk/python/mohawk/flower_client.py
@@ -1,0 +1,226 @@
+"""Flower compatibility helpers for the MOHAWK Python SDK."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+
+try:  # pragma: no cover - optional dependency
+    from flwr.client import NumPyClient as _FlowerNumPyClient
+except Exception:  # pragma: no cover - executed when Flower is not installed
+
+    class _FlowerNumPyClient:
+        """Fallback base class that mirrors Flower's NumPyClient surface."""
+
+        def get_parameters(self, config: Mapping[str, Any]):
+            raise NotImplementedError
+
+        def fit(self, parameters: Sequence[Any], config: Mapping[str, Any]):
+            raise NotImplementedError
+
+        def evaluate(self, parameters: Sequence[Any], config: Mapping[str, Any]):
+            raise NotImplementedError
+
+from .client import JsonDict, MohawkNode
+
+Scalar = Union[bool, int, float, str]
+TrainFn = Callable[[Sequence[Any], Mapping[str, Any]], Tuple[Sequence[Any], int, Mapping[str, Scalar]]]
+EvaluateFn = Callable[[Sequence[Any], Mapping[str, Any]], Tuple[float, int, Mapping[str, Scalar]]]
+
+
+@dataclass(frozen=True)
+class FlowerTrainingReport:
+    """Summary returned by the Mohawk Flower adapter after a round."""
+
+    node_id: str
+    num_examples: int
+    compression: JsonDict
+    proof_manifest: JsonDict
+    aggregation: JsonDict
+    metrics: JsonDict
+
+
+def _normalize_value(value: Any) -> Any:
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    if isinstance(value, Mapping):
+        return {str(key): _normalize_value(inner) for key, inner in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_normalize_value(item) for item in value]
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return base64.b64encode(bytes(value)).decode("ascii")
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _flatten_parameters(parameters: Sequence[Any]) -> List[float]:
+    flattened: List[float] = []
+
+    def _walk(value: Any) -> None:
+        if hasattr(value, "tolist"):
+            value = value.tolist()
+        if isinstance(value, Mapping):
+            for inner in value.values():
+                _walk(inner)
+            return
+        if isinstance(value, (list, tuple)):
+            for inner in value:
+                _walk(inner)
+            return
+        if isinstance(value, (bool, int, float)):
+            flattened.append(float(value))
+            return
+        try:
+            flattened.append(float(value))
+        except (TypeError, ValueError):
+            raise TypeError(f"unsupported parameter value for Flower bridge: {value!r}")
+
+    for parameter in parameters:
+        _walk(parameter)
+    return flattened
+
+
+def _hash_payload(*parts: Any) -> str:
+    normalized = [_normalize_value(part) for part in parts]
+    payload = json.dumps(normalized, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+class MohawkFlowerClient(_FlowerNumPyClient):
+    """Flower-compatible client wrapper around :class:`mohawk.client.MohawkNode`.
+
+    The caller supplies the local training and evaluation logic. The wrapper
+    handles Mohawk compression, proof-envelope generation, and aggregation
+    submission to the Go runtime.
+    """
+
+    def __init__(
+        self,
+        mohawk: MohawkNode,
+        *,
+        train_fn: TrainFn,
+        evaluate_fn: Optional[EvaluateFn] = None,
+        initial_parameters: Optional[Sequence[Any]] = None,
+        node_id: str = "flower-client",
+        compress_format: str = "auto",
+        max_norm: float = 1.0,
+        submit_updates: bool = True,
+        proof_namespace: str = "mohawk-flower",
+    ) -> None:
+        self.mohawk = mohawk
+        self._train_fn = train_fn
+        self._evaluate_fn = evaluate_fn
+        self._initial_parameters = list(initial_parameters) if initial_parameters is not None else None
+        self.node_id = node_id
+        self.compress_format = compress_format
+        self.max_norm = max_norm
+        self.submit_updates = submit_updates
+        self.proof_namespace = proof_namespace
+
+    def get_parameters(self, config: Mapping[str, Any]):
+        del config
+        if self._initial_parameters is None:
+            return []
+        return [parameter for parameter in self._initial_parameters]
+
+    def _build_proof_manifest(
+        self,
+        *,
+        input_parameters: Sequence[Any],
+        updated_parameters: Sequence[Any],
+        num_examples: int,
+        metrics: Mapping[str, Scalar],
+        compression: JsonDict,
+        config: Mapping[str, Any],
+    ) -> JsonDict:
+        round_number = int(config.get("server_round", 0) or 0)
+        manifest = {
+            "namespace": self.proof_namespace,
+            "node_id": self.node_id,
+            "round": round_number,
+            "num_examples": num_examples,
+            "input_hash": _hash_payload(input_parameters),
+            "output_hash": _hash_payload(updated_parameters),
+            "metrics_hash": _hash_payload(metrics),
+            "compression": {
+                "format": compression.get("format"),
+                "compressed_bytes": compression.get("compressed_bytes"),
+                "compression_ratio": compression.get("compression_ratio"),
+            },
+        }
+        manifest["proof"] = _hash_payload(manifest)
+        return manifest
+
+    def submit_update(
+        self,
+        *,
+        input_parameters: Sequence[Any],
+        updated_parameters: Sequence[Any],
+        num_examples: int,
+        metrics: Mapping[str, Scalar],
+        config: Mapping[str, Any],
+    ) -> FlowerTrainingReport:
+        flattened = _flatten_parameters(updated_parameters)
+        selected_format = config.get("mohawk_format", self.compress_format) or self.compress_format
+        selected_max_norm = config.get("mohawk_max_norm", self.max_norm) or self.max_norm
+        compression = self.mohawk.compress_gradients(
+            flattened,
+            format=str(selected_format),
+            max_norm=float(selected_max_norm),
+        )
+        proof_manifest = self._build_proof_manifest(
+            input_parameters=input_parameters,
+            updated_parameters=updated_parameters,
+            num_examples=num_examples,
+            metrics=metrics,
+            compression=compression,
+            config=config,
+        )
+        aggregation = {"success": True, "skipped": True}
+        if self.submit_updates:
+            aggregation = self.mohawk.aggregate(
+                [
+                    {
+                        "node_id": self.node_id,
+                        "gradient": flattened,
+                        "weight": float(num_examples),
+                    }
+                ]
+            )
+        return FlowerTrainingReport(
+            node_id=self.node_id,
+            num_examples=num_examples,
+            compression=compression,
+            proof_manifest=proof_manifest,
+            aggregation=aggregation,
+            metrics=dict(metrics),
+        )
+
+    def fit(self, parameters: Sequence[Any], config: Mapping[str, Any]):
+        current_parameters = [parameter for parameter in parameters]
+        updated_parameters, num_examples, metrics = self._train_fn(current_parameters, config)
+        report = self.submit_update(
+            input_parameters=current_parameters,
+            updated_parameters=updated_parameters,
+            num_examples=num_examples,
+            metrics=metrics,
+            config=config,
+        )
+        combined_metrics: JsonDict = {
+            **dict(metrics),
+            "mohawk_compressed_bytes": report.compression.get("compressed_bytes"),
+            "mohawk_compression_ratio": report.compression.get("compression_ratio"),
+            "mohawk_proof": report.proof_manifest["proof"],
+            "mohawk_round": report.proof_manifest["round"],
+        }
+        return list(updated_parameters), num_examples, combined_metrics
+
+    def evaluate(self, parameters: Sequence[Any], config: Mapping[str, Any]):
+        if self._evaluate_fn is None:
+            return 0.0, 0, {"mohawk_status": "evaluation skipped"}
+        loss, num_examples, metrics = self._evaluate_fn(list(parameters), config)
+        return loss, num_examples, dict(metrics)

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -29,6 +29,10 @@ keywords = ["federated-learning", "zk-snark", "blockchain", "privacy", "ai"]
 accelerator = [
     "numpy>=1.22",
 ]
+flower = [
+    "numpy>=1.22",
+    "flwr>=1.17,<2",
+]
 torch = [
     "numpy>=1.22",
     "torch>=2.0",

--- a/sdk/python/tests/test_flower_client.py
+++ b/sdk/python/tests/test_flower_client.py
@@ -1,0 +1,108 @@
+"""Tests for the Flower-compatible Mohawk client."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+class DummyMohawkNode:
+    def __init__(self):
+        self.compress_calls = []
+        self.aggregate_calls = []
+
+    def compress_gradients(self, gradients, *, format="auto", max_norm=1.0):
+        self.compress_calls.append(
+            {"gradients": list(gradients), "format": format, "max_norm": max_norm}
+        )
+        return {
+            "success": True,
+            "format": format,
+            "compressed_bytes": len(self.compress_calls[-1]["gradients"]) * 2,
+            "compression_ratio": 2.0,
+            "data_b64": "Y29tcHJlc3NlZA==",
+        }
+
+    def aggregate(self, updates):
+        payload = list(updates)
+        self.aggregate_calls.append(payload)
+        return {"success": True, "count": len(payload), "message": "Updates aggregated successfully"}
+
+
+def train_fn(parameters, config):
+    del config
+    updated = []
+    for tensor in parameters:
+        if isinstance(tensor, list):
+            updated.append([value + 1.0 for value in tensor])
+        else:
+            updated.append(tensor + 1.0)
+    return updated, 12, {"loss": 0.25}
+
+
+def evaluate_fn(parameters, config):
+    del parameters, config
+    return 0.25, 12, {"accuracy": 0.9}
+
+
+def test_fit_submits_update_and_builds_proof_manifest():
+    from mohawk.flower_client import MohawkFlowerClient
+
+    node = DummyMohawkNode()
+    client = MohawkFlowerClient(
+        node,
+        train_fn=train_fn,
+        evaluate_fn=evaluate_fn,
+        initial_parameters=[[0.0, 1.0], [2.0]],
+        node_id="demo-node",
+    )
+
+    parameters = client.get_parameters({})
+    updated_parameters, num_examples, metrics = client.fit(
+        parameters,
+        {"server_round": 7, "mohawk_format": "fp16"},
+    )
+
+    assert updated_parameters == [[1.0, 2.0], [3.0]]
+    assert num_examples == 12
+    assert metrics["loss"] == 0.25
+    assert metrics["mohawk_compression_ratio"] == 2.0
+    assert metrics["mohawk_proof"]
+    assert node.compress_calls[0]["format"] == "fp16"
+    assert node.aggregate_calls[0][0]["node_id"] == "demo-node"
+    assert node.aggregate_calls[0][0]["gradient"] == [1.0, 2.0, 3.0]
+    assert client.submit_updates is True
+
+
+def test_evaluate_uses_custom_callback():
+    from mohawk.flower_client import MohawkFlowerClient
+
+    client = MohawkFlowerClient(
+        DummyMohawkNode(),
+        train_fn=train_fn,
+        evaluate_fn=evaluate_fn,
+        initial_parameters=[[0.0]],
+    )
+
+    loss, num_examples, metrics = client.evaluate([[1.0]], {})
+    assert loss == 0.25
+    assert num_examples == 12
+    assert metrics["accuracy"] == 0.9
+
+
+def test_module_uses_flower_numpyclient_when_present(monkeypatch):
+    fake_flwr = types.ModuleType("flwr")
+    fake_client = types.ModuleType("flwr.client")
+
+    class FakeNumPyClient:
+        pass
+
+    fake_client.NumPyClient = FakeNumPyClient
+    fake_flwr.client = fake_client
+    monkeypatch.setitem(sys.modules, "flwr", fake_flwr)
+    monkeypatch.setitem(sys.modules, "flwr.client", fake_client)
+    monkeypatch.delitem(sys.modules, "mohawk.flower_client", raising=False)
+
+    module = importlib.import_module("mohawk.flower_client")
+    assert issubclass(module.MohawkFlowerClient, FakeNumPyClient)


### PR DESCRIPTION
This PR adds a scoped Flower integration proposal and a roadmap pointer.

Summary:
- Adds docs/flower-integration.md with a revised, repo-aligned plan for Flower-compatible client-side ML
- Narrows the original plan to a thin Python adapter, limited example ports, and optional strategy bridging
- Keeps Mohawk's Go runtime as the authoritative layer for aggregation, proofs, and hierarchy
- Adds a roadmap entry so the proposal is easy to find

Notes:
- This branch is documentation-only and does not implement the Flower adapter yet
- The plan intentionally avoids claims of zero-code-change integration or moving aggregation ownership out of Go