### PR TITLE
[AUDIT] Harden HTTP servers and file/exec safety surfaces

### DIFF
--- a/cmd/aggregator/main.go
+++ b/cmd/aggregator/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/internal/tpm"
 )
@@ -104,9 +105,16 @@ func main() {
 	}
 
 	http.HandleFunc("/aggregate", aggregateHandler)
+	server := &http.Server{
+		Addr:              ":" + port,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
 
 	fmt.Printf("Aggregator service starting on port %s...\n", port)
-	if err := http.ListenAndServe(":"+port, nil); err != nil {
+	if err := server.ListenAndServe(); err != nil {
 		log.Fatalf("Server failed: %v", err)
 	}
 }

--- a/cmd/api-dashboard/main.go
+++ b/cmd/api-dashboard/main.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"time"
 )
 
 type NetworkOverview struct {
@@ -39,5 +40,12 @@ func main() {
 	})
 
 	log.Println("api-dashboard listening on :8081")
-	log.Fatal(http.ListenAndServe(":8081", nil))
+	server := &http.Server{
+		Addr:              ":8081",
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+	log.Fatal(server.ListenAndServe())
 }

--- a/cmd/federated-router/main.go
+++ b/cmd/federated-router/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/internal/metrics"
@@ -30,15 +31,31 @@ func main() {
 		metricsAddr := defaultString(os.Getenv("MOHAWK_ROUTER_METRICS_ADDR"), "127.0.0.1:8088")
 		metricsMux := http.NewServeMux()
 		metricsMux.Handle("/metrics", promhttp.Handler())
+		metricsServer := &http.Server{
+			Addr:              metricsAddr,
+			Handler:           metricsMux,
+			ReadHeaderTimeout: 5 * time.Second,
+			ReadTimeout:       10 * time.Second,
+			WriteTimeout:      15 * time.Second,
+			IdleTimeout:       60 * time.Second,
+		}
 		log.Printf("metrics endpoint listening on %s", metricsAddr)
-		if err := http.ListenAndServe(metricsAddr, metricsMux); err != nil {
+		if err := metricsServer.ListenAndServe(); err != nil {
 			log.Printf("metrics server failed: %v", err)
 		}
 	}()
 
 	addr := defaultString(os.Getenv("MOHAWK_ROUTER_ADDR"), ":8087")
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           wrappedMux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
 	log.Printf("federated router listening on %s", addr)
-	if err := http.ListenAndServe(addr, wrappedMux); err != nil {
+	if err := server.ListenAndServe(); err != nil {
 		log.Fatalf("router server failed: %v", err)
 	}
 }

--- a/cmd/fl-aggregator/main.go
+++ b/cmd/fl-aggregator/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/internal/tpm"
 )
@@ -50,8 +51,15 @@ func authorizeRequest(r *http.Request) bool {
 
 func main() {
 	http.HandleFunc("/fl/submit", handleSubmit)
+	server := &http.Server{
+		Addr:              ":8090",
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
 	log.Println("FL aggregator on :8090")
-	log.Fatal(http.ListenAndServe(":8090", nil))
+	log.Fatal(server.ListenAndServe())
 }
 
 func handleSubmit(w http.ResponseWriter, r *http.Request) {

--- a/cmd/node-agent/main.go
+++ b/cmd/node-agent/main.go
@@ -396,8 +396,16 @@ func startMetricsServer(nodeID string) {
 	go func() {
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", promhttp.Handler())
+		server := &http.Server{
+			Addr:              metricsAddr,
+			Handler:           mux,
+			ReadHeaderTimeout: 5 * time.Second,
+			ReadTimeout:       10 * time.Second,
+			WriteTimeout:      15 * time.Second,
+			IdleTimeout:       60 * time.Second,
+		}
 		log.Printf("Node %s metrics listening on %s", nodeID, metricsAddr)
-		if err := http.ListenAndServe(metricsAddr, mux); err != nil {
+		if err := server.ListenAndServe(); err != nil {
 			log.Printf("Node %s metrics server stopped: %v", nodeID, err)
 		}
 	}()

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -141,8 +142,16 @@ func main() {
 	go func() {
 		metricsMux := http.NewServeMux()
 		metricsMux.Handle("/metrics", promhttp.Handler())
+		metricsServer := &http.Server{
+			Addr:              metricsAddr,
+			Handler:           metricsMux,
+			ReadHeaderTimeout: 5 * time.Second,
+			ReadTimeout:       10 * time.Second,
+			WriteTimeout:      15 * time.Second,
+			IdleTimeout:       60 * time.Second,
+		}
 		log.Printf("orchestrator metrics listening on %s", metricsAddr)
-		if err := http.ListenAndServe(metricsAddr, metricsMux); err != nil {
+		if err := metricsServer.ListenAndServe(); err != nil {
 			log.Fatalf("metrics server failed: %v", err)
 		}
 	}()
@@ -153,9 +162,13 @@ func main() {
 	}
 
 	httpServer := &http.Server{
-		Addr:      ":8080",
-		Handler:   mux,
-		TLSConfig: tlsConfig,
+		Addr:              ":8080",
+		Handler:           mux,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	log.Println("orchestrator listening with mTLS on :8080")
@@ -248,6 +261,11 @@ func loadSecretValue(envKey string, fileEnvKey string) string {
 	if secretFile == "" {
 		return ""
 	}
+	secretFile, err := sanitizePathInput(secretFile)
+	if err != nil {
+		log.Printf("warning: invalid %s path: %v", fileEnvKey, err)
+		return ""
+	}
 	content, err := os.ReadFile(secretFile)
 	if err != nil {
 		log.Printf("warning: failed to read %s: %v", fileEnvKey, err)
@@ -298,6 +316,12 @@ func observePQCPolicyMetrics() {
 }
 
 func observeThinkerClausesFromCapabilities(path string) {
+	cleanPath, err := sanitizePathInput(path)
+	if err != nil {
+		log.Printf("warning: invalid capabilities path %q: %v", path, err)
+		return
+	}
+
 	type thinkerClauses struct {
 		Enabled                         bool    `json:"enabled"`
 		PreserveOutliers                bool    `json:"preserve_outliers"`
@@ -310,7 +334,7 @@ func observeThinkerClausesFromCapabilities(path string) {
 		Thinker thinkerClauses `json:"thinker_clauses"`
 	}
 
-	raw, err := os.ReadFile(path)
+	raw, err := os.ReadFile(cleanPath)
 	if err != nil {
 		return
 	}
@@ -332,4 +356,24 @@ func observeThinkerClausesFromCapabilities(path string) {
 	metrics.ObserveThinkerClauseValue("minority_retention_max", cfg.Thinker.MinorityRetentionMax)
 	metrics.ObserveThinkerClauseValue("outlier_distance_zscore_cap", cfg.Thinker.OutlierDistanceZScoreCap)
 	metrics.ObserveThinkerClauseValue("manual_review_required_above_zscore", cfg.Thinker.ManualReviewRequiredAboveZScore)
+}
+
+func sanitizePathInput(raw string) (string, error) {
+	path := strings.TrimSpace(raw)
+	if path == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+	if strings.Contains(path, "\x00") {
+		return "", fmt.Errorf("path contains NUL byte")
+	}
+	for _, part := range strings.Split(path, string(filepath.Separator)) {
+		if part == ".." {
+			return "", fmt.Errorf("path traversal segment is not allowed")
+		}
+	}
+	cleaned := filepath.Clean(path)
+	if cleaned == "." || cleaned == ".." {
+		return "", fmt.Errorf("path does not resolve to a file")
+	}
+	return cleaned, nil
 }

--- a/cmd/pyapi-metrics-exporter/main.go
+++ b/cmd/pyapi-metrics-exporter/main.go
@@ -29,8 +29,16 @@ func main() {
 	})
 
 	addr := ":" + strconv.Itoa(port)
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
 	log.Printf("pyapi metrics exporter listening on %s", addr)
-	log.Fatal(http.ListenAndServe(addr, mux))
+	log.Fatal(server.ListenAndServe())
 }
 
 func emitSyntheticHybridAndCompression(interval time.Duration) {

--- a/cmd/testnet-gui/main.go
+++ b/cmd/testnet-gui/main.go
@@ -1058,12 +1058,12 @@ func fileExists(path string) bool {
 func openBrowser(url string) error {
 	switch runtime.GOOS {
 	case "linux":
-		if path, err := exec.LookPath("xdg-open"); err == nil && path != "" {
-			return exec.Command(path, url).Start()
+		if _, err := exec.LookPath("xdg-open"); err == nil {
+			return exec.Command("xdg-open", url).Start()
 		}
 	case "darwin":
-		if path, err := exec.LookPath("open"); err == nil && path != "" {
-			return exec.Command(path, url).Start()
+		if _, err := exec.LookPath("open"); err == nil {
+			return exec.Command("open", url).Start()
 		}
 	}
 	return errors.New("browser launch is not available")

--- a/cmd/tpm-metrics/main.go
+++ b/cmd/tpm-metrics/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -63,5 +64,13 @@ func main() {
 	})
 
 	log.Printf("TPM metrics exporter listening on %s", addr)
-	log.Fatal(http.ListenAndServe(addr, mux))
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+	log.Fatal(server.ListenAndServe())
 }

--- a/internal/accelerator/aggregate.go
+++ b/internal/accelerator/aggregate.go
@@ -27,7 +27,7 @@ const autoParallelMinElements = 262144
 
 var (
 	aggregateWorkersMu      sync.Mutex
-	aggregateWorkersByShape = map[uint64]int{}
+	aggregateWorkersByShape = map[[2]int]int{}
 	partialBufferPool       sync.Pool
 )
 
@@ -70,7 +70,7 @@ func ResolveAggregateWorkers(numGradients int, dim int, requestedWorkers int) in
 		workers = numGradients
 	}
 
-	shape := (uint64(uint32(numGradients)) << 32) | uint64(uint32(dim))
+	shape := [2]int{numGradients, dim}
 	aggregateWorkersMu.Lock()
 	if prev, ok := aggregateWorkersByShape[shape]; ok {
 		if workers > prev+1 {

--- a/internal/accelerator/quantize.go
+++ b/internal/accelerator/quantize.go
@@ -19,6 +19,8 @@ import (
 	"math"
 )
 
+const maxUint16Value = 1<<16 - 1
+
 // FP32ToFP16 converts a float32 slice to IEEE 754 half-precision bytes (2 bytes
 // per element, little-endian). Halving the payload from 4 B/param → 2 B/param
 // yields a ~50% wire compression ratio for gradient transmission.
@@ -95,17 +97,24 @@ func f32ToF16Bits(f float32) uint16 {
 	case rawExp <= 0:
 		// Sub-normal or underflow
 		if rawExp < -10 {
-			return uint16(sign)
+			return uint16FromUint32Bounded(sign)
 		}
 		mantissa |= 0x800000
 		mantissa >>= uint(1 - rawExp)
-		return uint16(sign | uint32(mantissa>>13))
+		return uint16FromUint32Bounded(sign | uint32(mantissa>>13))
 	case rawExp >= 31:
 		// Overflow → infinity
-		return uint16(sign | 0x7c00)
+		return uint16FromUint32Bounded(sign | 0x7c00)
 	default:
-		return uint16(sign | uint32(rawExp<<10) | (mantissa >> 13))
+		return uint16FromUint32Bounded(sign | uint32(rawExp<<10) | (mantissa >> 13))
 	}
+}
+
+func uint16FromUint32Bounded(v uint32) uint16 {
+	if v > maxUint16Value {
+		return maxUint16Value
+	}
+	return uint16(v)
 }
 
 // f16BitsToF32 decodes an FP16 bit pattern to float32.

--- a/internal/hybrid/verifier.go
+++ b/internal/hybrid/verifier.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -78,6 +79,15 @@ var (
 	snarkAccelMu       sync.RWMutex
 	snarkAccelerator   SNARKAccelerator
 )
+
+var allowedExternalVerifierBinaries = map[string]struct{}{
+	"python":            {},
+	"python3":           {},
+	"node":              {},
+	"stark-verify":      {},
+	"snark-verify":      {},
+	"winterfell-verify": {},
+}
 
 func init() {
 	RegisterSTARKBackend(friVerifier{})
@@ -331,7 +341,29 @@ func parseExternalCommand(raw string) (string, []string, error) {
 	if len(parts) == 0 {
 		return "", nil, fmt.Errorf("external command is empty")
 	}
-	return parts[0], parts[1:], nil
+	bin, err := sanitizeExternalExecutable(parts[0])
+	if err != nil {
+		return "", nil, err
+	}
+	return bin, parts[1:], nil
+}
+
+func sanitizeExternalExecutable(raw string) (string, error) {
+	bin := strings.TrimSpace(raw)
+	if bin == "" {
+		return "", fmt.Errorf("external executable is empty")
+	}
+	if strings.Contains(bin, "\x00") {
+		return "", fmt.Errorf("external executable contains NUL byte")
+	}
+	base := filepath.Base(filepath.Clean(bin))
+	if base == "." || base == "" {
+		return "", fmt.Errorf("external executable is invalid")
+	}
+	if _, ok := allowedExternalVerifierBinaries[base]; !ok {
+		return "", fmt.Errorf("external executable %q is not allowlisted", base)
+	}
+	return base, nil
 }
 
 func (externalCommandVerifier) BackendName() string { return "external_cmd" }

--- a/internal/tpm/tpm.go
+++ b/internal/tpm/tpm.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -481,6 +482,14 @@ func enforceProductionHardwareTPMBuild() error {
 }
 
 func loadAuthorityFromFiles(certPath string, keyPath string) (*Authority, error) {
+	certPath, err := sanitizePathInput(certPath)
+	if err != nil {
+		return nil, fmt.Errorf("invalid tpm ca cert path: %w", err)
+	}
+	keyPath, err = sanitizePathInput(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("invalid tpm ca key path: %w", err)
+	}
 	certPEM, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, fmt.Errorf("read tpm ca cert %q: %w", certPath, err)
@@ -524,6 +533,10 @@ func loadAuthorityFromFiles(certPath string, keyPath string) (*Authority, error)
 }
 
 func loadAuthorityCertFromFile(certPath string) (*Authority, error) {
+	certPath, err := sanitizePathInput(certPath)
+	if err != nil {
+		return nil, fmt.Errorf("invalid tpm ca cert path: %w", err)
+	}
 	certPEM, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, fmt.Errorf("read tpm ca cert %q: %w", certPath, err)
@@ -559,6 +572,10 @@ func allowAuthorityFallback(certPath string, keyPath string, loadErr error) bool
 }
 
 func pathStatMissingOrDir(path string) bool {
+	path, err := sanitizePathInput(path)
+	if err != nil {
+		return true
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		return os.IsNotExist(err)
@@ -692,6 +709,14 @@ func newAttestor(nodeID string, authority *Authority) (*Attestor, error) {
 func newAttestorFromFiles(nodeID string, authority *Authority, certPath string, keyPath string) (*Attestor, error) {
 	if authority == nil || authority.cert == nil {
 		return nil, fmt.Errorf("authority is not configured")
+	}
+	certPath, err := sanitizePathInput(certPath)
+	if err != nil {
+		return nil, fmt.Errorf("invalid tpm cert path: %w", err)
+	}
+	keyPath, err = sanitizePathInput(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("invalid tpm key path: %w", err)
 	}
 	certPEM, err := os.ReadFile(certPath)
 	if err != nil {
@@ -932,6 +957,10 @@ func loadHashSeed(nodeID string) ([32]byte, string, error) {
 		}
 		source = "env-hex"
 	} else if seedFile != "" {
+		seedFile, err = sanitizePathInput(seedFile)
+		if err != nil {
+			return seed, "", fmt.Errorf("invalid MOHAWK_TPM_HASHSIG_SEED_FILE: %w", err)
+		}
 		content, readErr := os.ReadFile(seedFile)
 		if readErr != nil {
 			return seed, "", fmt.Errorf("read MOHAWK_TPM_HASHSIG_SEED_FILE: %w", readErr)
@@ -959,4 +988,24 @@ func loadHashSeed(nodeID string) ([32]byte, string, error) {
 	copy(seed[:], raw)
 	idDigest := sha256.Sum256([]byte(nodeID + ":" + source + ":" + hex.EncodeToString(seed[:])))
 	return seed, hex.EncodeToString(idDigest[:8]), nil
+}
+
+func sanitizePathInput(raw string) (string, error) {
+	path := strings.TrimSpace(raw)
+	if path == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+	if strings.Contains(path, "\x00") {
+		return "", fmt.Errorf("path contains NUL byte")
+	}
+	for _, part := range strings.Split(path, string(filepath.Separator)) {
+		if part == ".." {
+			return "", fmt.Errorf("path traversal segment is not allowed")
+		}
+	}
+	cleaned := filepath.Clean(path)
+	if cleaned == "." || cleaned == ".." {
+		return "", fmt.Errorf("path does not resolve to a file")
+	}
+	return cleaned, nil
 }

--- a/internal/wasmhost/host.go
+++ b/internal/wasmhost/host.go
@@ -462,7 +462,11 @@ func (h *Host) Verify(ctx context.Context, proof []byte) (bool, error) {
 	}
 
 	// Theorem 5: Constant-time verification check
-	results, err := fn.Call(ctx, uint64(len(proof)))
+	proofLen, err := safeUint64FromInt(len(proof))
+	if err != nil {
+		return false, err
+	}
+	results, err := fn.Call(ctx, proofLen)
 	if err != nil {
 		return false, fmt.Errorf("wasm execution error: %w", err)
 	}
@@ -477,6 +481,13 @@ func (h *Host) Verify(ctx context.Context, proof []byte) (bool, error) {
 // FastVerify is an optimized alias for the Verify method.
 func (h *Host) FastVerify(ctx context.Context, proof []byte) (bool, error) {
 	return h.Verify(ctx, proof)
+}
+
+func safeUint64FromInt(v int) (uint64, error) {
+	if v < 0 {
+		return 0, fmt.Errorf("negative value %d cannot be converted to uint64", v)
+	}
+	return uint64(v), nil
 }
 
 // Close releases Wasm resources.


### PR DESCRIPTION
## Summary
This PR implements the critical and high-priority hardening actions from the benchmark and security report generated on 2026-04-26.

## Security Fixes Included
1. Add HTTP server timeouts (DoS hardening)
- Replaced bare `http.ListenAndServe(...)` usage with `http.Server` instances configured with:
  - `ReadHeaderTimeout: 5s`
  - `ReadTimeout: 10s`
  - `WriteTimeout: 15s`
  - `IdleTimeout: 60s`
- Applied to:
  - `cmd/aggregator/main.go`
  - `cmd/fl-aggregator/main.go`
  - `cmd/federated-router/main.go` (public + metrics listeners)
  - `cmd/orchestrator/main.go` (public + metrics listeners)
  - `cmd/node-agent/main.go` (metrics listener)
  - `cmd/api-dashboard/main.go`
  - `cmd/pyapi-metrics-exporter/main.go`
  - `cmd/tpm-metrics/main.go`

2. Path traversal defenses for file reads
- Added path sanitization (`filepath.Clean`, traversal-segment rejection, NUL-byte rejection) before file operations on externally supplied paths.
- Applied to:
  - `internal/tpm/tpm.go` (CA cert/key paths, node cert/key paths, hash seed file path, stat checks)
  - `cmd/orchestrator/main.go` (secret file path + capabilities file path)

3. Integer overflow / narrowing hardening
- Removed overflow-prone shape key packing via `int -> uint32` casts in aggregator worker cache; now uses a typed composite key.
- Added bounded conversion helper in FP16 conversion path to avoid unchecked narrowing.
- Added safe int-to-uint64 conversion helper before wasm host call boundary.
- Applied to:
  - `internal/accelerator/aggregate.go`
  - `internal/accelerator/quantize.go`
  - `internal/wasmhost/host.go`

4. Command execution hardening
- Added executable sanitization + allowlist for external hybrid verifier backends.
- Removed variable command-path execution in testnet GUI browser launcher (fixed command names after availability checks).
- Applied to:
  - `internal/hybrid/verifier.go`
  - `cmd/testnet-gui/main.go`

## Benchmark & Security Context
From the attached report:
- CVEs found: 0 (govulncheck)
- Aggregation throughput: up to 26.0 GB/s at peak configuration
- 59 gosec findings identified, with critical/high focus areas addressed in this PR:
  - missing HTTP timeouts
  - path traversal risk surfaces
  - integer narrowing risks
  - command execution safety

## Validation Per CONTRIBUTING.md
- Toolchain guard: `scripts/ensure_go_toolchain.sh` sourced during lint step.
- Lint command executed: `make lint` (completed in this environment; Python ruff module was unavailable).
- `make test` attempted (failed due expected local service dependency: orchestrator not running).
- Functional fallback validation completed: `go test ./...` passed.

## Notes
- This PR focuses on code-level hardening in the highest-priority paths from the report.
- Remaining medium/low findings (log injection cleanup, broader error-path handling, orchestration coverage expansion) are suitable for follow-up PRs.
