### PR TITLE
[AUDIT] Follow-up: redact errors, sanitize logs, expand orchestrator coverage

### DIFF
--- a/cmd/aggregator/main.go
+++ b/cmd/aggregator/main.go
@@ -47,7 +47,8 @@ func aggregateHandler(w http.ResponseWriter, r *http.Request) {
 
 	var updates []Update
 	if err := json.NewDecoder(r.Body).Decode(&updates); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		http.Error(w, "bad request", http.StatusBadRequest)
+		log.Printf("aggregate decode error: %v", err)
 		return
 	}
 
@@ -57,8 +58,9 @@ func aggregateHandler(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"status":            "failed",
 			"formal_check_pass": false,
-			"message":           err.Error(),
+			"message":           "formal verification check failed",
 		})
+		log.Printf("formal verification check failed: %v", err)
 		return
 	}
 

--- a/cmd/federated-router/main.go
+++ b/cmd/federated-router/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -146,7 +147,12 @@ func publishHandler(r *router.Router) http.HandlerFunc {
 		if offer.SourceVertical == "" || offer.ModelID == "" || offer.PublisherNodeID == "" || len(offer.PublisherQuote) == 0 {
 			metrics.ObserveRouterRequest("publish", false, "validation")
 			http.Error(w, "invalid request", http.StatusBadRequest)
-			log.Printf("publish validation failed: %+v", offer)
+			log.Printf("publish validation failed: source=%s model=%s node=%s quote_len=%d",
+				sanitizeLogValue(offer.SourceVertical),
+				sanitizeLogValue(offer.ModelID),
+				sanitizeLogValue(offer.PublisherNodeID),
+				len(offer.PublisherQuote),
+			)
 			return
 		}
 		published, err := r.PublishInsight(offer)
@@ -179,7 +185,12 @@ func subscribeHandler(r *router.Router) http.HandlerFunc {
 		if sub.SubscriberVertical == "" || len(sub.SourceVerticals) == 0 || sub.SubscriberNodeID == "" || len(sub.SubscriberQuote) == 0 {
 			metrics.ObserveRouterRequest("subscribe", false, "validation")
 			http.Error(w, "invalid request", http.StatusBadRequest)
-			log.Printf("subscribe validation failed: %+v", sub)
+			log.Printf("subscribe validation failed: subscriber=%s node=%s source_count=%d quote_len=%d",
+				sanitizeLogValue(sub.SubscriberVertical),
+				sanitizeLogValue(sub.SubscriberNodeID),
+				len(sub.SourceVerticals),
+				len(sub.SubscriberQuote),
+			)
 			return
 		}
 		if err := r.RegisterSubscription(sub); err != nil {
@@ -204,7 +215,8 @@ func discoverHandler(r *router.Router) http.HandlerFunc {
 		offers, err := r.Discover(subscriber)
 		if err != nil {
 			metrics.ObserveRouterRequest("discover", false, classifyRouterError(err))
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			http.Error(w, "request failed", http.StatusBadRequest)
+			log.Printf("discover failed for subscriber=%s: %v", sanitizeLogValue(subscriber), err)
 			return
 		}
 		metrics.ObserveRouterRequest("discover", true, "none")
@@ -232,7 +244,12 @@ func provenanceHandler(r *router.Router) http.HandlerFunc {
 			if event.OfferID == "" || event.SourceVertical == "" || event.TargetVertical == "" || event.SubscriberModel == "" {
 				metrics.ObserveRouterRequest("provenance_post", false, "validation")
 				http.Error(w, "invalid request", http.StatusBadRequest)
-				log.Printf("provenance validation failed: %+v", event)
+				log.Printf("provenance validation failed: offer=%s source=%s target=%s subscriber_model=%s",
+					sanitizeLogValue(event.OfferID),
+					sanitizeLogValue(event.SourceVertical),
+					sanitizeLogValue(event.TargetVertical),
+					sanitizeLogValue(event.SubscriberModel),
+				)
 				return
 			}
 			record, err := r.RecordTransfer(event)
@@ -303,6 +320,29 @@ func ensureWriteJSON(w http.ResponseWriter, value any) {
 	if err := json.NewEncoder(w).Encode(value); err != nil {
 		http.Error(w, fmt.Sprintf("encode response: %v", err), http.StatusInternalServerError)
 	}
+}
+
+func sanitizeLogValue(value string) string {
+	if value == "" {
+		return ""
+	}
+	b := strings.Builder{}
+	b.Grow(len(value))
+	for _, r := range value {
+		if r == '\n' || r == '\r' || r == '\t' {
+			b.WriteRune(' ')
+			continue
+		}
+		if strconv.IsPrint(r) {
+			b.WriteRune(r)
+		}
+	}
+	cleaned := strings.TrimSpace(b.String())
+	const maxLen = 120
+	if len(cleaned) > maxLen {
+		return cleaned[:maxLen] + "..."
+	}
+	return cleaned
 }
 
 func parseRoutes(raw string) map[string][]string {

--- a/cmd/orchestrator/server.go
+++ b/cmd/orchestrator/server.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -175,7 +176,8 @@ func (s *Server) HandleCheckpointPut(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	cid, err := s.Checkpoints.PutCheckpoint(ctx, req.Name, []byte(req.Payload))
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadGateway)
+		log.Printf("checkpoint put failed for name=%q: %v", req.Name, err)
+		http.Error(w, "checkpoint storage failed", http.StatusBadGateway)
 		return
 	}
 	_ = json.NewEncoder(w).Encode(map[string]string{"cid": cid})
@@ -197,7 +199,8 @@ func (s *Server) HandleCheckpointGet(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	payload, err := s.Checkpoints.GetCheckpoint(ctx, cid)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadGateway)
+		log.Printf("checkpoint get failed for cid=%q: %v", cid, err)
+		http.Error(w, "checkpoint retrieval failed", http.StatusBadGateway)
 		return
 	}
 	_ = json.NewEncoder(w).Encode(map[string]string{"payload": string(payload)})
@@ -216,7 +219,8 @@ func (s *Server) HandleMeshPlan(w http.ResponseWriter, r *http.Request) {
 	}
 	plan, err := hva.BuildPlan(totalNodes, dimensions)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		log.Printf("mesh plan build failed: total_nodes=%d dimensions=%d err=%v", totalNodes, dimensions, err)
+		http.Error(w, "invalid mesh parameters", http.StatusBadRequest)
 		return
 	}
 	_ = json.NewEncoder(w).Encode(plan)

--- a/cmd/orchestrator/server_security_test.go
+++ b/cmd/orchestrator/server_security_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/internal/ipfs"
 )
 
 func TestAuthorizeAdmin_FailClosedWhenTokenMissing(t *testing.T) {
@@ -44,5 +47,93 @@ func TestHandleAttest_RejectsOversizedBody(t *testing.T) {
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for oversized payload, got %d", rr.Code)
+	}
+}
+
+func TestHandleCheckpointPut_RedactsBackendError(t *testing.T) {
+	ipfsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "backend auth token leaked", http.StatusInternalServerError)
+	}))
+	defer ipfsServer.Close()
+
+	s := &Server{Checkpoints: ipfs.NewBackend(ipfsServer.URL)}
+	req := httptest.NewRequest(http.MethodPost, "/checkpoints/put", strings.NewReader(`{"name":"state.json","payload":"abc"}`))
+	rr := httptest.NewRecorder()
+
+	s.HandleCheckpointPut(rr, req)
+
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "checkpoint storage failed") {
+		t.Fatalf("expected redacted backend message, got %q", body)
+	}
+	if strings.Contains(body, "backend auth token leaked") {
+		t.Fatalf("response leaked backend details: %q", body)
+	}
+}
+
+func TestHandleCheckpointGet_RedactsBackendError(t *testing.T) {
+	ipfsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "cid lookup exposed internals", http.StatusInternalServerError)
+	}))
+	defer ipfsServer.Close()
+
+	s := &Server{Checkpoints: ipfs.NewBackend(ipfsServer.URL)}
+	req := httptest.NewRequest(http.MethodGet, "/checkpoints/get?cid=abc123", nil)
+	rr := httptest.NewRecorder()
+
+	s.HandleCheckpointGet(rr, req)
+
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "checkpoint retrieval failed") {
+		t.Fatalf("expected redacted backend message, got %q", body)
+	}
+	if strings.Contains(body, "cid lookup exposed internals") {
+		t.Fatalf("response leaked backend details: %q", body)
+	}
+}
+
+func TestHandleMeshPlan_ReturnsGenericValidationError(t *testing.T) {
+	s := &Server{MeshDimensions: 1024}
+	req := httptest.NewRequest(http.MethodGet, "/mesh/plan?total_nodes=100&dimensions=0", nil)
+	rr := httptest.NewRecorder()
+
+	s.HandleMeshPlan(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "invalid mesh parameters") {
+		t.Fatalf("expected generic error message, got %q", body)
+	}
+}
+
+func TestHandleCheckpointGet_SuccessReturnsPayloadJSON(t *testing.T) {
+	ipfsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("payload-data"))
+	}))
+	defer ipfsServer.Close()
+
+	s := &Server{Checkpoints: ipfs.NewBackend(ipfsServer.URL)}
+	req := httptest.NewRequest(http.MethodGet, "/checkpoints/get?cid=abc123", nil)
+	rr := httptest.NewRecorder()
+
+	s.HandleCheckpointGet(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var response map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("expected valid json response: %v", err)
+	}
+	if response["payload"] != "payload-data" {
+		t.Fatalf("unexpected payload %q", response["payload"])
 	}
 }


### PR DESCRIPTION
## Summary
This stacked follow-up PR closes the remaining medium/low audit tracks in one pass by tightening response/error handling and reducing log-injection exposure, while expanding orchestration security coverage.

## Changes
- Redacted raw internal errors from client responses in orchestrator handlers:
  - `HandleCheckpointPut` now returns `checkpoint storage failed`
  - `HandleCheckpointGet` now returns `checkpoint retrieval failed`
  - `HandleMeshPlan` now returns `invalid mesh parameters`
  - Detailed failures are preserved in server logs for operators.
- Hardened router logging to avoid logging full user-controlled structs with `%+v`:
  - `publish`, `subscribe`, and `provenance` validation logs now emit scoped/sanitized fields.
  - Added `sanitizeLogValue` helper to strip control characters and truncate oversized values.
- Removed direct raw error disclosure from router discovery and aggregator decode/formal-check responses.
- Expanded orchestration tests to cover redaction and error paths:
  - backend error redaction for checkpoint put/get
  - generic mesh-plan validation response
  - checkpoint get success JSON behavior remains validated

## Validation
- `TOOLROOT=/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.linux-amd64 GOROOT=$TOOLROOT PATH=$TOOLROOT/bin:$PATH GOTOOLCHAIN=local go test ./cmd/orchestrator ./cmd/federated-router ./cmd/aggregator`

## Scope
This PR intentionally targets medium/low hardening items only (log injection cleanup, broader error-path handling, orchestration coverage expansion) and is stacked on top of the active critical/high hardening branch.