### PR TITLE
[AUDIT] Follow-up: harden gradient stream errors and debug logs

### DIFF
--- a/cmd/node-agent/main.go
+++ b/cmd/node-agent/main.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	"unicode"
 
 	corehost "github.com/libp2p/go-libp2p/core/host"
 	libp2ppeer "github.com/libp2p/go-libp2p/core/peer"
@@ -333,7 +334,7 @@ func sendGradientUpdate(ctx context.Context, conf Config, plan hva.Plan, peerHos
 		if remoteMode == "" {
 			metrics.ObserveAcceleratorOp("cpu", "gradient_submit", false)
 			metrics.ObserveAcceleratorOpLatency("cpu", "gradient_submit", float64(time.Since(gradStart).Microseconds())/1000.0)
-			log.Printf("Gradient: orchestrator advertised unsupported KEX mode %q", info.KEXMode)
+			log.Printf("Gradient: orchestrator advertised unsupported KEX mode=%q", sanitizeLogValue(info.KEXMode))
 			return
 		}
 		if remoteMode != conf.TransportKEXMode {
@@ -353,14 +354,14 @@ func sendGradientUpdate(ctx context.Context, conf Config, plan hva.Plan, peerHos
 	if err != nil {
 		metrics.ObserveAcceleratorOp("cpu", "gradient_submit", false)
 		metrics.ObserveAcceleratorOpLatency("cpu", "gradient_submit", float64(time.Since(gradStart).Microseconds())/1000.0)
-		log.Printf("Gradient: invalid orchestrator peer ID %q: %v", info.PeerID, err)
+		log.Printf("Gradient: invalid orchestrator peer ID=%q: %v", sanitizeLogValue(info.PeerID), err)
 		return
 	}
 	orchAddrs := make([]multiaddr.Multiaddr, 0, len(info.Addrs))
 	for _, a := range info.Addrs {
 		ma, err := multiaddr.NewMultiaddr(a)
 		if err != nil {
-			log.Printf("Gradient: skipping invalid addr %q: %v", a, err)
+			log.Printf("Gradient: skipping invalid addr=%q: %v", sanitizeLogValue(a), err)
 			continue
 		}
 		orchAddrs = append(orchAddrs, ma)
@@ -382,10 +383,10 @@ func sendGradientUpdate(ctx context.Context, conf Config, plan hva.Plan, peerHos
 	metrics.ObserveAcceleratorOp("cpu", "gradient_submit", ack.Accepted)
 	metrics.ObserveAcceleratorOpLatency("cpu", "gradient_submit", float64(time.Since(gradStart).Microseconds())/1000.0)
 	if !ack.Accepted {
-		log.Printf("Gradient: sent round=%d len=%d -> accepted=%v reason=%q negotiated_kex=%q kex_pubkey_len=%d", msg.Round, len(msg.Gradients), ack.Accepted, ack.Reason, ack.NegotiatedKEX, ack.KEXPublicKeyLen)
+		log.Printf("Gradient: sent round=%d len=%d -> accepted=%v reason=%q negotiated_kex=%q kex_pubkey_len=%d", msg.Round, len(msg.Gradients), ack.Accepted, sanitizeLogValue(ack.Reason), sanitizeLogValue(ack.NegotiatedKEX), ack.KEXPublicKeyLen)
 		return
 	}
-	log.Printf("Gradient: sent round=%d len=%d -> accepted=%v negotiated_kex=%q kex_pubkey_len=%d", msg.Round, len(msg.Gradients), ack.Accepted, ack.NegotiatedKEX, ack.KEXPublicKeyLen)
+	log.Printf("Gradient: sent round=%d len=%d -> accepted=%v negotiated_kex=%q kex_pubkey_len=%d", msg.Round, len(msg.Gradients), ack.Accepted, sanitizeLogValue(ack.NegotiatedKEX), ack.KEXPublicKeyLen)
 }
 
 func startMetricsServer(nodeID string) {
@@ -404,9 +405,9 @@ func startMetricsServer(nodeID string) {
 			WriteTimeout:      15 * time.Second,
 			IdleTimeout:       60 * time.Second,
 		}
-		log.Printf("Node %s metrics listening on %s", nodeID, metricsAddr)
+		log.Printf("Node %s metrics listening on %s", sanitizeLogValue(nodeID), sanitizeLogValue(metricsAddr))
 		if err := server.ListenAndServe(); err != nil {
-			log.Printf("Node %s metrics server stopped: %v", nodeID, err)
+			log.Printf("Node %s metrics server stopped: %v", sanitizeLogValue(nodeID), err)
 		}
 	}()
 }
@@ -609,4 +610,27 @@ func splitCSV(value string) []string {
 		}
 	}
 	return out
+}
+
+func sanitizeLogValue(value string) string {
+	if value == "" {
+		return ""
+	}
+	b := strings.Builder{}
+	b.Grow(len(value))
+	for _, r := range value {
+		if r == '\n' || r == '\r' || r == '\t' {
+			b.WriteRune(' ')
+			continue
+		}
+		if unicode.IsPrint(r) {
+			b.WriteRune(r)
+		}
+	}
+	cleaned := strings.TrimSpace(b.String())
+	const maxLen = 120
+	if len(cleaned) > maxLen {
+		return cleaned[:maxLen] + "..."
+	}
+	return cleaned
 }

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -29,6 +29,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/internal/accelerator"
@@ -116,8 +117,8 @@ func main() {
 	// Register the libp2p gradient-submission protocol so edge nodes can deliver
 	// gradient updates directly over the encrypted p2p transport.
 	network.RegisterGradientHandlerWithKEX(transportHost, kexMode, func(msg *network.GradientMessage) *network.GradientAck {
-		log.Printf("gradient received: node=%s task=%s round=%d len=%d",
-			msg.NodeID, msg.TaskID, msg.Round, len(msg.Gradients))
+		log.Printf("gradient received: round=%d len=%d node=%s task=%s",
+			msg.Round, len(msg.Gradients), sanitizeLogValue(msg.NodeID), sanitizeLogValue(msg.TaskID))
 		return &network.GradientAck{Accepted: true, NegotiatedKEX: string(kexMode), KEXPublicKeyLen: kexMode.ExpectedPublicKeyBytes()}
 	})
 
@@ -150,7 +151,7 @@ func main() {
 			WriteTimeout:      15 * time.Second,
 			IdleTimeout:       60 * time.Second,
 		}
-		log.Printf("orchestrator metrics listening on %s", metricsAddr)
+		log.Printf("orchestrator metrics listening on %s", sanitizeLogValue(metricsAddr))
 		if err := metricsServer.ListenAndServe(); err != nil {
 			log.Fatalf("metrics server failed: %v", err)
 		}
@@ -176,7 +177,9 @@ func main() {
 }
 
 func handlePubkey(w http.ResponseWriter, r *http.Request) {
-	_, _ = w.Write([]byte(hex.EncodeToString(orchPub)))
+	if _, err := w.Write([]byte(hex.EncodeToString(orchPub))); err != nil {
+		log.Printf("failed to write pubkey response: %v", err)
+	}
 }
 
 func handleNextJob(w http.ResponseWriter, r *http.Request) {
@@ -236,6 +239,29 @@ func defaultPort(value string, fallback int) int {
 		return fallback
 	}
 	return parsed
+}
+
+func sanitizeLogValue(value string) string {
+	if value == "" {
+		return ""
+	}
+	b := strings.Builder{}
+	b.Grow(len(value))
+	for _, r := range value {
+		if r == '\n' || r == '\r' || r == '\t' {
+			b.WriteRune(' ')
+			continue
+		}
+		if unicode.IsPrint(r) {
+			b.WriteRune(r)
+		}
+	}
+	cleaned := strings.TrimSpace(b.String())
+	const maxLen = 120
+	if len(cleaned) > maxLen {
+		return cleaned[:maxLen] + "..."
+	}
+	return cleaned
 }
 
 func splitRelayAddrs(value string) []string {

--- a/internal/network/gradient.go
+++ b/internal/network/gradient.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"time"
 
 	corehost "github.com/libp2p/go-libp2p/core/host"
@@ -72,7 +73,8 @@ func RegisterGradientHandlerWithKEX(h corehost.Host, expectedMode KEXMode, onGra
 		defer s.Close()
 		payload, err := io.ReadAll(bufio.NewReader(s))
 		if err != nil {
-			s.Reset()
+			log.Printf("gradient: failed to read stream payload: %v", err)
+			resetStreamWithLog(s, "read_payload")
 			return
 		}
 
@@ -83,16 +85,16 @@ func RegisterGradientHandlerWithKEX(h corehost.Host, expectedMode KEXMode, onGra
 		if err := json.Unmarshal(payload, &env); err == nil && (env.Message.NodeID != "" || len(env.Messages) > 0) {
 			mode := ParseKEXMode(env.KEXMode)
 			if mode == "" {
-				_ = json.NewEncoder(s).Encode(&GradientAck{Accepted: false, Reason: fmt.Sprintf("unsupported kex mode %q", env.KEXMode)})
+				writeAckWithLog(s, &GradientAck{Accepted: false, Reason: fmt.Sprintf("unsupported kex mode %q", env.KEXMode)}, "unsupported_kex")
 				return
 			}
 			if expectedMode != "" && mode != expectedMode {
-				_ = json.NewEncoder(s).Encode(&GradientAck{Accepted: false, Reason: fmt.Sprintf("kex mismatch expected=%s got=%s", expectedMode, mode)})
+				writeAckWithLog(s, &GradientAck{Accepted: false, Reason: fmt.Sprintf("kex mismatch expected=%s got=%s", expectedMode, mode)}, "kex_mismatch")
 				return
 			}
 			expectedBytes := mode.ExpectedPublicKeyBytes()
 			if expectedBytes > 0 && len(env.KEXPublicKey) != expectedBytes {
-				_ = json.NewEncoder(s).Encode(&GradientAck{Accepted: false, Reason: fmt.Sprintf("kex public key bytes mismatch expected=%d got=%d", expectedBytes, len(env.KEXPublicKey))})
+				writeAckWithLog(s, &GradientAck{Accepted: false, Reason: fmt.Sprintf("kex public key bytes mismatch expected=%d got=%d", expectedBytes, len(env.KEXPublicKey))}, "kex_key_mismatch")
 				return
 			}
 			ackMeta.NegotiatedKEX = string(mode)
@@ -115,12 +117,13 @@ func RegisterGradientHandlerWithKEX(h corehost.Host, expectedMode KEXMode, onGra
 						}
 					}
 				}
-				_ = json.NewEncoder(s).Encode(batchAck)
+				writeAckWithLog(s, batchAck, "batch_ack")
 				return
 			}
 			msg = env.Message
 		} else if err := json.Unmarshal(payload, &msg); err != nil {
-			s.Reset()
+			log.Printf("gradient: failed to decode payload: %v", err)
+			resetStreamWithLog(s, "decode_payload")
 			return
 		}
 
@@ -134,7 +137,7 @@ func RegisterGradientHandlerWithKEX(h corehost.Host, expectedMode KEXMode, onGra
 		if ack.KEXPublicKeyLen == 0 {
 			ack.KEXPublicKeyLen = ackMeta.KEXPublicKeyLen
 		}
-		_ = json.NewEncoder(s).Encode(ack)
+		writeAckWithLog(s, ack, "single_ack")
 	})
 }
 
@@ -175,7 +178,9 @@ func SendGradientWithKEX(ctx context.Context, h corehost.Host, peerID peer.ID, p
 	if err := json.NewEncoder(s).Encode(&env); err != nil {
 		return nil, fmt.Errorf("gradient: send: %w", err)
 	}
-	_ = s.CloseWrite()
+	if err := s.CloseWrite(); err != nil {
+		log.Printf("gradient: close write failed: %v", err)
+	}
 	var ack GradientAck
 	if err := json.NewDecoder(bufio.NewReader(s)).Decode(&ack); err != nil {
 		return nil, fmt.Errorf("gradient: read ack: %w", err)
@@ -228,7 +233,9 @@ func SendGradientBatchWithKEX(ctx context.Context, h corehost.Host, peerID peer.
 	if err := json.NewEncoder(s).Encode(&env); err != nil {
 		return nil, fmt.Errorf("gradient: send batch: %w", err)
 	}
-	_ = s.CloseWrite()
+	if err := s.CloseWrite(); err != nil {
+		log.Printf("gradient: close write for batch failed: %v", err)
+	}
 	var ack GradientAck
 	if err := json.NewDecoder(bufio.NewReader(s)).Decode(&ack); err != nil {
 		return nil, fmt.Errorf("gradient: read batch ack: %w", err)
@@ -246,4 +253,17 @@ func generateKEXPublicKey(mode KEXMode) ([]byte, error) {
 		return nil, fmt.Errorf("gradient: generate kex public key: %w", err)
 	}
 	return key, nil
+}
+
+func resetStreamWithLog(s corenetwork.Stream, context string) {
+	if err := s.Reset(); err != nil {
+		log.Printf("gradient: stream reset failed (%s): %v", context, err)
+	}
+}
+
+func writeAckWithLog(s corenetwork.Stream, ack *GradientAck, context string) {
+	if err := json.NewEncoder(s).Encode(ack); err != nil {
+		log.Printf("gradient: ack encode failed (%s): %v", context, err)
+		resetStreamWithLog(s, context+"_ack_encode")
+	}
 }


### PR DESCRIPTION
## Summary
This follow-up PR addresses the remaining low-severity audit items in one pass for:
- CWE-117 (log injection surface in debug logging)
- CWE-703 (ignored/non-explicitly handled errors in gradient stream paths)

## What Changed
- `internal/network/gradient.go`
  - Replaced ignored stream error paths with explicit handling/logging:
    - read/decode failures now log and attempt reset with error logging
    - ack writes now use a helper that logs encode failures and stream-reset failures
    - `CloseWrite()` errors are now explicitly checked and logged (single and batch send paths)
- `cmd/node-agent/main.go`
  - Sanitized remote-influenced debug log fields in gradient submission flow:
    - advertised KEX mode, peer ID, remote addrs, ack reason/negotiated KEX
  - Sanitized node/metrics address values in metrics server logging
  - Added `sanitizeLogValue` helper (control-char stripping + truncation)
- `cmd/orchestrator/main.go`
  - Sanitized gradient receive debug logs for node/task values
  - Sanitized metrics listener address logging
  - Replaced ignored pubkey write result with explicit error handling and logging
  - Added `sanitizeLogValue` helper

## Validation
- `TOOLROOT=/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.9.linux-amd64 GOROOT=$TOOLROOT PATH=$TOOLROOT/bin:$PATH GOTOOLCHAIN=local go test ./internal/network ./cmd/node-agent ./cmd/orchestrator`

## Notes
- `gosec` CLI was not available in this environment for a direct local delta scan.