### PR TITLE
feat: launch the full genesis stack

### DIFF
--- a/genesis-launch.sh
+++ b/genesis-launch.sh
@@ -108,7 +108,21 @@ fi
 echo "Launching regional shard: $MOHAWK_REGIONAL_SHARD"
 echo "Metrics profile: $MOHAWK_METRICS_PROFILE"
 
-"$COMPOSE_CMD" up -d orchestrator shard-us-east federated-router tpm-metrics prometheus grafana ipfs
+CORE_SERVICES=(
+  orchestrator
+  shard-us-east
+  shard-eu-west
+  federated-router
+  tpm-metrics
+  pyapi-metrics-exporter
+  accelerator-detect
+  prometheus
+  alertmanager
+  grafana
+  ipfs
+)
+
+"$COMPOSE_CMD" up -d "${CORE_SERVICES[@]}"
 
 for i in {1..45}; do
   if docker logs orchestrator 2>&1 | grep -q "orchestrator listening with mTLS on :8080"; then


### PR DESCRIPTION
## Description
Expand `genesis-launch.sh` so the genesis entrypoint starts the broader compose stack instead of only the core orchestration services.

### What changed
- Added `shard-eu-west` to the default launch set.
- Added `alertmanager` so monitoring starts with the rest of the stack.
- Added `pyapi-metrics-exporter` and `accelerator-detect` so accelerator-related observability is available from genesis startup.
- Kept the node-agent scaling flow unchanged.

### Formal Proof Context
- Not applicable.
- No proof files or Lean sources were changed.

### Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance optimization
- [ ] Documentation update

## Performance Impact Assessment

**Affected Operations**
- [ ] `verify_proof()` / `verify_proof_batch()`
- [ ] `aggregate()` at any node count
- [ ] `fl_round_e2e()` federated learning pipeline
- [ ] `attest()` node attestation
- [ ] `load_wasm()` module loading
- [x] None (documentation/config only)

**Benchmark Results**
- Before: not applicable for this launcher-only change.
- After: not applicable for this launcher-only change.

**Benchmark Notes**
- [x] No performance impact expected (launcher/orchestration change only)

**Regression Risk**
- [x] ✅ No performance impact (verified by code inspection and targeted shell validation)

## Testing
- [x] `bash -n genesis-launch.sh`
- [x] Branch pushed to origin
- [ ] `make test` passes
- [ ] `./test_all.sh` passes
- [ ] Python SDK tests pass (`make test-python-sdk`)

## Documentation
- [ ] README.md updated (if applicable)
- [ ] CHANGELOG.md updated
- [ ] Code comments added for complex logic
- [ ] API documentation updated (if applicable)

## Related Issues
- Closes #

## Special Notes for Reviewers
This change only widens the default genesis compose startup set. The pyapi autotuner is already wired in runtime code through `BuildAutoTuneProfile(...)`; the launcher change makes the supporting observability/services come up with genesis.
