### PR TITLE
Fix genesis launch startup ordering

### DIFF
--- a/genesis-launch.sh
+++ b/genesis-launch.sh
@@ -145,13 +145,6 @@ if [[ "$(docker inspect -f '{{.State.Health.Status}}' federated-router 2>/dev/nu
   exit 1
 fi
 
-for i in {1..30}; do
-  if [[ "$(docker inspect -f '{{.State.Health.Status}}' ops-assistant 2>/dev/null || true)" == "healthy" ]]; then
-    break
-  fi
-  sleep 2
-done
-
 if [[ "$NODE_MODE" == "all" ]]; then
   "$COMPOSE_CMD" up -d node-agent-1 node-agent-2 node-agent-3
   expected_nodes=3
@@ -224,6 +217,10 @@ if [[ "$running_nodes" -lt "$expected_nodes" ]]; then
     docker logs "$name" --tail 200 2>&1 || true
   done
   exit 1
+fi
+
+if [[ "$(docker inspect -f '{{.State.Health.Status}}' ops-assistant 2>/dev/null || true)" != "healthy" ]]; then
+  echo "warning: ops-assistant is not healthy yet; continuing with orchestrator and node agents" >&2
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- Stop `genesis-launch.sh` from blocking node-agent startup on the ops-assistant health gate
- Keep ops-assistant health as a best-effort warning after the core stack is up

## Validation
- `docker compose -f docker-compose.yml config`
- `docker build -f web/ops-assistant/Dockerfile .`
- `bash -n genesis-launch.sh`
- `./genesis-launch.sh --help`