### PR TITLE
[AUDIT] feat(ops-assistant): harden deployment, CORS, and observability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,9 @@ Common pitfalls and fixes:
   * Run `scripts/validate_host_network_tuning.sh` and then apply via `sudo bash scripts/host_tuning.sh --persist`.
 * Docker Desktop + TPM flow mismatch on non-Linux hosts:
   * Use `make strict-auth-smoke-container` to validate the glibc path in a reproducible container.
+* Windows checkout fails with `Filename too long`:
+  * Enable long paths before cloning or checking out: `git config --system core.longpaths true`.
+  * If the repository is still too deep for the host, clone it into a shorter path such as `C:\src\Sovereign-Mohawk-Proto`.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -340,6 +340,12 @@ services:
       - grafana-data:/var/lib/grafana
     depends_on:
       - prometheus
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:3000/api/health >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 15s
     deploy:
       resources:
         limits:
@@ -359,11 +365,16 @@ services:
     container_name: ops-assistant
     environment:
       - PROMETHEUS_URL=http://prometheus:9090
+      - GRAFANA_URL=http://grafana:3000
+      - GRAFANA_API_TOKEN=${GRAFANA_API_TOKEN:-admin}
+      - CORS_ORIGIN=http://localhost:3001,http://localhost:5173
       - NODE_ENV=production
     ports:
       - "3001:3000"
     depends_on:
       prometheus:
+        condition: service_healthy
+      grafana:
         condition: service_healthy
     deploy:
       resources:

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -37,3 +37,8 @@ scrape_configs:
     metrics_path: /metrics
     static_configs:
       - targets: ["federated-router:8088"]
+
+  - job_name: ops-assistant
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["ops-assistant:3000"]

--- a/web/ops-assistant/.env.example
+++ b/web/ops-assistant/.env.example
@@ -1,6 +1,14 @@
 # Prometheus API endpoint
 PROMETHEUS_URL=http://prometheus:9090
 
+# Grafana API endpoint and auth token
+GRAFANA_URL=http://grafana:3000
+GRAFANA_API_TOKEN=admin
+
+# Restrict browser access when the frontend is served from another origin
+CORS_ORIGIN=http://localhost:3000,http://localhost:3001,http://localhost:5173
+CORS_METHODS=GET,POST,OPTIONS
+
 # Server configuration
 PORT=3000
 NODE_ENV=production

--- a/web/ops-assistant/Dockerfile
+++ b/web/ops-assistant/Dockerfile
@@ -40,6 +40,7 @@ COPY --from=builder /app/dist ./dist
 ENV NODE_ENV=production
 ENV PORT=3000
 ENV PROMETHEUS_URL=http://prometheus:9090
+ENV GRAFANA_URL=http://grafana:3000
 
 # Health check
 HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \

--- a/web/ops-assistant/README.md
+++ b/web/ops-assistant/README.md
@@ -39,6 +39,10 @@ npm start
 
 ```
 PROMETHEUS_URL=http://prometheus:9090   # Prometheus API endpoint
+GRAFANA_URL=http://grafana:3000         # Grafana API endpoint
+GRAFANA_API_TOKEN=admin                 # Grafana API token with dashboard read privileges
+CORS_ORIGIN=http://localhost:3000       # Comma-separated browser origins allowed to call the API
+CORS_METHODS=GET,POST,OPTIONS           # Allowed CORS methods
 PORT=3000                                # Backend port
 NODE_ENV=production                      # Environment
 VITE_API_BASE_URL=http://localhost:3000  # Frontend API base URL (optional)
@@ -124,7 +128,11 @@ Multi-stage build for optimized production images:
 
 ```bash
 docker build -t ops-assistant:latest .
-docker run -e PROMETHEUS_URL=http://prometheus:9090 -p 3000:3000 ops-assistant:latest
+docker run \
+  -e PROMETHEUS_URL=http://prometheus:9090 \
+  -e GRAFANA_URL=http://grafana:3000 \
+  -p 3000:3000 \
+  ops-assistant:latest
 ```
 
 ## Integration with docker-compose
@@ -139,9 +147,13 @@ ops-assistant:
     - "3001:3000"
   environment:
     - PROMETHEUS_URL=http://prometheus:9090
+    - GRAFANA_URL=http://grafana:3000
+    - GRAFANA_API_TOKEN=${GRAFANA_API_TOKEN}
+    - CORS_ORIGIN=http://localhost:3001,http://localhost:5173
     - NODE_ENV=production
   depends_on:
     - prometheus
+    - grafana
   networks:
     - mohawk-net
   healthcheck:
@@ -152,6 +164,8 @@ ops-assistant:
 ```
 
 Then access at: `http://localhost:3001`
+
+If you expose the API from a different browser origin, set `CORS_ORIGIN` to a comma-separated allowlist of exact origins before starting the server.
 
 ## Project Structure
 

--- a/web/ops-assistant/server/index.ts
+++ b/web/ops-assistant/server/index.ts
@@ -29,9 +29,24 @@ const app: Express = express();
 const port = process.env.PORT || 3000;
 const prometheusUrl = process.env.PROMETHEUS_URL || 'http://prometheus:9090';
 const grafanaUrl = process.env.GRAFANA_URL || 'http://grafana:3000';
+const corsOrigins = (process.env.CORS_ORIGIN || '')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+const corsMethods = (process.env.CORS_METHODS || 'GET,POST,OPTIONS')
+  .split(',')
+  .map((method) => method.trim())
+  .filter(Boolean);
 
 // Middleware
-app.use(cors());
+app.use(
+  cors({
+    origin: corsOrigins.length > 0 ? corsOrigins : false,
+    methods: corsMethods,
+    allowedHeaders: ['Content-Type', 'Authorization'],
+    credentials: true,
+  })
+);
 app.use(express.json());
 
 // Create HTTP server for WebSocket support
@@ -74,9 +89,21 @@ function emitSseEvent(res: Response, event: AgUiEvent) {
  */
 wss.on('connection', (ws: WebSocket, _req: http.IncomingMessage) => {
   const clientId = `client_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  const remoteAddress = _req.socket.remoteAddress || 'unknown';
 
-  console.log(`[Server] New WebSocket connection: ${clientId}`);
-  wsManager.registerClient(clientId, ws);
+  console.log(`[Server] New WebSocket connection: ${clientId} from ${remoteAddress}`);
+  ws.on('error', (error) => {
+    console.error(`[Server] WebSocket error for ${clientId}:`, error);
+  });
+  ws.on('close', (code, reason) => {
+    const closeReason = reason.toString() || 'no reason provided';
+    console.log(`[Server] WebSocket closed: ${clientId} code=${code} reason=${closeReason}`);
+  });
+  ws.on('message', (message) => {
+    const preview = message.toString().slice(0, 160);
+    console.log(`[Server] WebSocket message from ${clientId}: ${preview}`);
+  });
+  wsManager.registerClient(clientId, ws, remoteAddress);
 
   // Send welcome message
   ws.send(

--- a/web/ops-assistant/server/websocket-manager.ts
+++ b/web/ops-assistant/server/websocket-manager.ts
@@ -12,6 +12,7 @@ interface Client {
   ws: WebSocket;
   subscriptions: Set<string>;
   connected: boolean;
+  remoteAddress?: string;
 }
 
 interface MetricSubscription {
@@ -35,12 +36,13 @@ export class WebSocketManager extends EventEmitter {
   /**
    * Register a WebSocket client
    */
-  registerClient(clientId: string, ws: WebSocket): void {
+  registerClient(clientId: string, ws: WebSocket, remoteAddress?: string): void {
     const client: Client = {
       id: clientId,
       ws,
       subscriptions: new Set(),
       connected: true,
+      remoteAddress,
     };
 
     this.clients.set(clientId, client);
@@ -50,7 +52,9 @@ export class WebSocketManager extends EventEmitter {
     ws.on('close', () => this.handleDisconnect(clientId));
     ws.on('error', (error) => this.handleError(clientId, error));
 
-    console.log(`[WebSocket] Client registered: ${clientId}`);
+    console.log(
+      `[WebSocket] Client registered: ${clientId}${remoteAddress ? ` from ${remoteAddress}` : ''}`
+    );
     this.emit('client_connected', { clientId });
   }
 
@@ -60,6 +64,7 @@ export class WebSocketManager extends EventEmitter {
   private handleMessage(clientId: string, data: WebSocket.Data): void {
     try {
       const message = JSON.parse(data.toString());
+      console.log(`[WebSocket] Message from ${clientId}: ${message.type}`);
 
       switch (message.type) {
         case 'subscribe':
@@ -280,7 +285,9 @@ export class WebSocketManager extends EventEmitter {
     this.clients.delete(clientId);
     this.messageQueue.delete(clientId);
 
-    console.log(`[WebSocket] Client disconnected: ${clientId}`);
+    console.log(
+      `[WebSocket] Client disconnected: ${clientId}${client.remoteAddress ? ` from ${client.remoteAddress}` : ''}`
+    );
     this.emit('client_disconnected', { clientId });
   }
 


### PR DESCRIPTION
## Summary
- Wire ops-assistant deployment defaults for Grafana and Prometheus in Docker/compose.
- Restrict Express CORS via environment configuration instead of allowing all origins.
- Improve WebSocket connection, message, close, and error logging with remote address tracking.
- Add an ops-assistant scrape target to Prometheus monitoring.
- Document environment variables, Docker usage, and Windows long-path checkout troubleshooting.

## Validation
- `npm run build --silent` in `web/ops-assistant`
- `docker compose config`
- `get_errors` on `web/ops-assistant/server/index.ts` and `web/ops-assistant/server/websocket-manager.ts` returned no errors

## Notes
- `GRAFANA_API_TOKEN` is passed through compose for deployments that require authenticated Grafana access.
- `CORS_ORIGIN` and `CORS_METHODS` are now configurable to match browser deployments.
- Added a Windows checkout workaround for `Filename too long` failures in the contributor guide.