### PR TITLE
[AUDIT] feat(ops-assistant): harden deployment, CORS, observability, and FL smoke coverage

### DIFF
--- a/.github/workflows/monitoring-smoke-gate.yml
+++ b/.github/workflows/monitoring-smoke-gate.yml
@@ -34,18 +34,59 @@ jobs:
 
       - name: Start monitoring stack
         run: |
-          docker compose up -d --build orchestrator prometheus tpm-metrics pyapi-metrics-exporter grafana
+          docker compose up -d --build orchestrator prometheus tpm-metrics pyapi-metrics-exporter grafana ops-assistant
 
       - name: Wait for Prometheus and Grafana
         run: |
           for _ in $(seq 1 60); do
-            if curl -fsS http://localhost:9090/-/healthy >/dev/null 2>&1 && curl -fsS http://localhost:3000/api/health >/dev/null 2>&1; then
+            if curl -fsS http://localhost:9090/-/healthy >/dev/null 2>&1 && curl -fsS http://localhost:3000/api/health >/dev/null 2>&1 && curl -fsS http://localhost:3001/api/health >/dev/null 2>&1; then
               exit 0
             fi
             sleep 2
           done
           echo "Prometheus/Grafana did not become healthy in time"
           exit 1
+
+      - name: Validate ops-assistant endpoints
+        run: |
+          python3 - <<'PY'
+          import json
+          import time
+          import urllib.request
+          from statistics import mean
+
+          endpoints = {
+              'health': 'http://localhost:3001/api/health',
+              'summary': 'http://localhost:3001/api/ops/summary',
+              'metrics': 'http://localhost:3001/metrics',
+          }
+
+          timings = {name: [] for name in endpoints}
+
+          for _ in range(5):
+              for name, url in endpoints.items():
+                  start = time.perf_counter()
+                  with urllib.request.urlopen(url, timeout=15) as resp:
+                      body = resp.read().decode('utf-8')
+                  elapsed = time.perf_counter() - start
+                  timings[name].append(elapsed)
+
+                  if name == 'summary':
+                      payload = json.loads(body)
+                      if 'federatedIntelligence' not in payload:
+                          raise SystemExit('ops summary missing federatedIntelligence payload')
+                  elif name == 'metrics':
+                      if 'sov_mohawk_federated_drift_score' not in body:
+                          raise SystemExit('metrics output missing federated drift metric')
+
+          summary_avg_ms = mean(timings['summary']) * 1000.0
+          summary_max_ms = max(timings['summary']) * 1000.0
+
+          if summary_max_ms > 2500:
+              raise SystemExit(f'ops summary latency too high: {summary_max_ms:.1f}ms')
+
+          print('ops-assistant latency ms avg/max:', f'{summary_avg_ms:.1f}', f'{summary_max_ms:.1f}')
+          PY
 
       - name: Verify Prometheus targets
         run: |
@@ -97,6 +138,7 @@ jobs:
           checks = {
               "mohawk_metrics_family": "count({__name__=~\"mohawk_.*\"})",
               "tpm_metrics_family": "count({__name__=~\"mohawk_tpm_.*\"})",
+              "federated_metrics_family": "count({__name__=~\"mohawk:federated_.*\"})",
           }
 
           output = {}

--- a/docs/FEDERATED_RUNBOOK.md
+++ b/docs/FEDERATED_RUNBOOK.md
@@ -38,6 +38,11 @@ Operator steps for manual review:
 
 - Monitor `sov_mohawk_federated_drift_score` and create a recording rule/alert when > 0.5 for sustained windows.
 - Alert when `sov_mohawk_federated_anomalies_total{severity="high"}` increases.
+- Prometheus recording rules are available for:
+	- `mohawk:federated_drift_score:avg5m`
+	- `mohawk:federated_round_progress:avg5m`
+	- `mohawk:federated_anomalies:increase5m`
+	- `mohawk:federated_high_anomalies:increase5m`
 
 ## Contact & Escalation
 

--- a/monitoring/prometheus/recording-rules.yml
+++ b/monitoring/prometheus/recording-rules.yml
@@ -94,3 +94,15 @@ groups:
         expr: stddev_over_time(mohawk_aggregation_workers[5m])
       - record: mohawk:fedavg_gradient_throughput:avg5m
         expr: avg_over_time(mohawk_fedavg_gradient_throughput_per_sec[5m])
+
+  - name: mohawk_v2_federated_intelligence
+    interval: 30s
+    rules:
+      - record: mohawk:federated_drift_score:avg5m
+        expr: avg_over_time(sov_mohawk_federated_drift_score[5m])
+      - record: mohawk:federated_round_progress:avg5m
+        expr: avg_over_time(sov_mohawk_federated_round_progress[5m])
+      - record: mohawk:federated_anomalies:increase5m
+        expr: sum(increase(sov_mohawk_federated_anomalies_total[5m]))
+      - record: mohawk:federated_high_anomalies:increase5m
+        expr: sum(increase(sov_mohawk_federated_anomalies_total{severity="high"}[5m]))

--- a/web/ops-assistant/server/federated-intelligence.ts
+++ b/web/ops-assistant/server/federated-intelligence.ts
@@ -7,6 +7,11 @@ function getFederationApiUrl(): string {
   return process.env.FEDERATION_API_URL || 'http://federation-api:8080';
 }
 
+function getFederationApiTimeoutMs(): number {
+  const parsed = Number(process.env.FEDERATION_API_TIMEOUT_MS || '1000');
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1000;
+}
+
 export type FLRoundPhase =
   | 'initialization'
   | 'client_selection'
@@ -139,7 +144,7 @@ async function fetchFederationSnapshot(): Promise<RoundSnapshot | null> {
   try {
     const FEDERATION_API_URL = getFederationApiUrl();
     const response = await axios.get(`${FEDERATION_API_URL}/api/v1/round/current`, {
-      timeout: 5000,
+      timeout: getFederationApiTimeoutMs(),
     });
 
     const payload = response.data?.data ?? response.data;

--- a/web/ops-assistant/server/index.ts
+++ b/web/ops-assistant/server/index.ts
@@ -350,7 +350,8 @@ app.get('/api/actions', (req: Request, res: Response) => {
  */
 app.get('/api/ops/summary', async (_req: Request, res: Response) => {
   try {
-    const [promHealthy, grafanaHealth, alertsResponse, uptimeResponse, errorRateResponse] =
+    const federatedOverviewPromise = getFederatedOverview();
+    const [promHealthy, grafanaHealth, alertsResponse, uptimeResponse, errorRateResponse, federatedOverview] =
       await Promise.all([
         queryPrometheusHealth(),
         grafanaClient.getHealth(),
@@ -367,9 +368,8 @@ app.get('/api/ops/summary', async (_req: Request, res: Response) => {
           },
           timeout: 5000,
         }),
+        federatedOverviewPromise,
       ]);
-
-    const federatedOverview = await getFederatedOverview();
 
     const uptimeRaw = parseFloat(uptimeResponse.data?.data?.result?.[0]?.value?.[1] || '0');
     const errorRateRaw = parseFloat(


### PR DESCRIPTION
## Summary
- Wire ops-assistant deployment defaults for Grafana and Prometheus in Docker/compose.
- Restrict Express CORS via environment configuration instead of allowing all origins.
- Improve WebSocket connection, message, close, and error logging with remote address tracking.
- Add an ops-assistant scrape target to Prometheus monitoring.
- Add federated-intelligence Prometheus recording rules.
- Extend the monitoring smoke gate to exercise ops-assistant health, summary, metrics, and latency.
- Document environment variables, Docker usage, FL metrics, and Windows long-path checkout troubleshooting.

## Validation
- `npm run build --silent` in `web/ops-assistant`
- `docker compose config`
- `python3` YAML syntax validation for:
  - `monitoring/prometheus/recording-rules.yml`
  - `.github/workflows/monitoring-smoke-gate.yml`
  - `docs/FEDERATED_RUNBOOK.md`
- `get_errors` on `web/ops-assistant/server/index.ts` and `web/ops-assistant/server/websocket-manager.ts` returned no errors

## Notes
- `GRAFANA_API_TOKEN` is passed through compose for deployments that require authenticated Grafana access.
- `CORS_ORIGIN` and `CORS_METHODS` are configurable to match browser deployments.
- `mohawk:federated_*` recording rules were added for round drift, progress, and anomaly counters.
- Added a Windows checkout workaround for `Filename too long` failures in the contributor guide.