### PR TITLE
security(orchestrator): remove MOHAWK_ALLOW_UNAUTH_ADMIN backdoor

### DIFF
--- a/cmd/orchestrator/server.go
+++ b/cmd/orchestrator/server.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -382,14 +381,17 @@ func (s *Server) HandleMigrationTransfer(w http.ResponseWriter, r *http.Request)
 	success = true
 }
 
+// authorizeAdmin validates the Bearer token for all admin endpoints.
+// A missing or empty AdminToken is always an error — there is no bypass.
+// Configure AdminToken with a cryptographically random 256-bit (32-byte) value.
 func (s *Server) authorizeAdmin(w http.ResponseWriter, r *http.Request) bool {
 	expected := strings.TrimSpace(s.AdminToken)
 	if expected == "" {
-		if strings.EqualFold(strings.TrimSpace(os.Getenv("MOHAWK_ALLOW_UNAUTH_ADMIN")), "true") {
-			return true
-		}
+		// Fail-closed: an unconfigured token blocks all admin access.
+		// Previously this path allowed bypass via MOHAWK_ALLOW_UNAUTH_ADMIN; that
+		// env-var backdoor has been removed. Configure AdminToken before deploying.
 		metrics.ObserveAuthzDenial(strings.TrimSpace(r.URL.Path), "admin_token_not_configured")
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		http.Error(w, "unauthorized: admin token not configured on server", http.StatusUnauthorized)
 		return false
 	}
 	auth := strings.TrimSpace(r.Header.Get("Authorization"))


### PR DESCRIPTION
Problem (CWE-288 — Authentication Bypass Using Alternate Path):
  authorizeAdmin() contained a hidden bypass:

    if expected == "" {
        if os.Getenv("MOHAWK_ALLOW_UNAUTH_ADMIN") == "true" {
            return true  // ← all admin endpoints fully open
        }
    }

  Any deployment where AdminToken is unconfigured (common in dev/staging
  pipelines where secrets are injected late) AND where an attacker or
  misconfigured CI/CD environment sets this env var gains unauthenticated
  access to all admin endpoints: /admin/peers, /admin/config,
  /admin/policy — including the ability to modify routing policy and
  drain peer connections.

  The env-var pattern is particularly dangerous because it can be
  inherited silently from a parent process or injected via docker-compose
  environment blocks without appearing in application config.

Fix:
  The bypass branch is removed entirely. An unconfigured AdminToken now
  always returns HTTP 401 with a descriptive error message advising the
  operator to configure the token. Fail-closed semantics.

  The constant-time comparison path (subtle.ConstantTimeCompare) for
  configured tokens is unchanged and correct.

  Removed unused "os" import.

Operator action required:
  Set AdminToken to a cryptographically random 256-bit value before
  deploying. The server will refuse all admin requests until this is done,
  which is the intended behavior.

## Description
<!-- Provide a clear and concise description of your changes -->

### Formal Proof Context (required for proof/validation PRs)
- Related PR(s): #48
- Traceability updates included:
  - [ ] `proofs/FORMAL_TRACEABILITY_MATRIX.md` updated
  - [ ] Lean-to-Go refinement mapping explained in description
  - [ ] Any theorem refinement changes called out explicitly

### Lean Build & Validation Checklist (required for proof/validation PRs)
- [ ] `cd proofs && lake build` passes locally
- [ ] No placeholder tactics (`sorry`/`admit`/`axiom`) introduced
- [ ] Formal validation script executed (attach command + output summary)
- [ ] CI formal validation status noted in this PR description

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance optimization
- [ ] Documentation update

## 📊 Performance Impact Assessment (MANDATORY)

**⚠️ All PRs affecting core operations must complete this section**

### Affected Operations
<!-- Check all that apply -->
- [ ] `verify_proof()` / `verify_proof_batch()`
- [ ] `aggregate()` at any node count
- [ ] `fl_round_e2e()` federated learning pipeline
- [ ] `attest()` node attestation
- [ ] `load_wasm()` module loading
- [ ] None (documentation/config only)

### Benchmark Results
<!-- Required if any operations checked above -->

**Before this PR:**
```
# Paste baseline benchmark results
# Example: aggregate(nodes=100): mean 22.3ms, throughput 44.9 ops/s
```

**After this PR:**
```
# Paste new benchmark results from pytest-benchmark
# Run: cd sdk/python && pytest tests/test_benchmarks.py --benchmark-only
```

**Performance Delta:**
- Latency change: ___% (decrease is better)
- Throughput change: ___% (increase is better)
- Memory change: ___MB

**Benchmark Notes:**
- [ ] No performance impact expected (proof/docs-only change)
- [ ] Performance impact measured and summarized above
- Notes:
```
# Include rationale when selecting "No performance impact expected"
# Example: Lean theorem/tactic refactor only, no runtime Go path changes.
```

### Regression Risk
<!-- Check one -->
- [ ] ✅ No performance impact (verified by benchmarks)
- [ ] 🟡 Minor improvement (<10% latency reduction OR <10% throughput gain)
- [ ] 🟢 Significant improvement (≥10% latency reduction OR ≥10% throughput gain)
- [ ] ⚠️ Contains performance regression (requires architectural justification)

**If regression detected, provide justification:**
<!-- Explain why the regression is acceptable and what compensating benefits exist -->

## ✅ Performance Gate Compliance

### Critical Thresholds (from sdk_optimization_report.json)
Your changes must not violate these limits:

- [ ] `verify_proof(batch=100)`: P99 < 6ms, throughput > 140 ops/s
- [ ] `aggregate(nodes=100)`: mean < 25ms, throughput > 40 ops/s
- [ ] `fl_round_e2e(10 nodes)`: mean < 12ms, P99 < 18ms
- [ ] `attest()`: mean < 0.3ms, throughput > 4000 ops/s
- [ ] `load_wasm(4096KB)`: mean < 0.35ms

**CI Performance Gate Status:** 
<!-- Will be automatically updated by GitHub Actions -->

## Testing

### Unit Tests
- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Test coverage maintained or improved

### Integration Tests
- [ ] `make test` passes
- [ ] `./test_all.sh` passes
- [ ] Python SDK tests pass (`make test-python-sdk`)

### Manual Testing
<!-- Describe manual testing performed -->

## Documentation
- [ ] README.md updated (if applicable)
- [ ] CHANGELOG.md updated
- [ ] Code comments added for complex logic
- [ ] API documentation updated (if applicable)

## Related Issues
<!-- Link related issues using #issue_number -->
Closes #

## Artifact Review Checklist
- [ ] Scope is clear: code changes only, evidence changes only, or mixed by design
- [ ] Canonical summary updated: `captured_artifacts/artifact_evidence_summary.md`
- [ ] Canonical manifest updated: `captured_artifacts/artifact_manifest_latest.json`
- [ ] Retention policy applied (`make artifact-retention-apply`)
- [ ] If evidence files are included, PR description links canonical files first

## Checklist Before Requesting Review
- [ ] Code follows project style guidelines (`make lint`)
- [ ] No linter errors or warnings
- [ ] Performance benchmarks completed and passing
- [ ] All tests passing locally
- [ ] Commit messages follow conventional commits format
- [ ] Branch is up-to-date with main
- [ ] No merge conflicts

## Special Notes for Reviewers
<!-- Any additional context or areas that need special attention -->

---

**⚠️  FIX-4 Reminder:** Per REC-05 in sdk_optimization_report.json, any PR introducing >30% FL round latency increase or >20% throughput decrease must be blocked pending investigation.