### PR TITLE
Use constant-time comparison in VerifyZKProof

### DIFF
--- a/internal/proofs/verifier.go
+++ b/internal/proofs/verifier.go
@@ -4,6 +4,7 @@ package proofs
 
 import (
 	"crypto/sha256"
+	"crypto/subtle"
 	"fmt"
 )
 
@@ -25,7 +26,12 @@ func VerifyZKProof(expectedRoot string, proofData []byte, salt [32]byte) (bool, 
 	}
 
 	actualRoot := fmt.Sprintf("%x", h.Sum(nil))
-	if actualRoot != expectedRoot {
+	// Constant-time comparison: the caller-supplied expectedRoot isn't a secret
+	// in any current call path (see internal/router.PublishInsight, which takes
+	// both expectedRoot and proofData from the same request), but this is an
+	// exported, general-purpose verifier - hardening it here is free and avoids
+	// relying on that being true for every future caller.
+	if subtle.ConstantTimeCompare([]byte(actualRoot), []byte(expectedRoot)) != 1 {
 		return false, fmt.Errorf("integrity check failed: expected %s, got %s", expectedRoot, actualRoot)
 	}
 


### PR DESCRIPTION
## Summary

`internal/proofs.VerifyZKProof` compared the computed and expected proof
roots with a plain `!=` string comparison instead of a constant-time one.

Traced the threat model before deciding whether this was worth fixing:
in every current call path it isn't actually exploitable.
`internal/router.PublishInsight` takes `expectedRoot` and `proofData`
from the *same* caller-submitted request (`offer.ExpectedProofRoot` /
`offer.ProofPayload`), so a would-be timing attacker already knows both
values — this is a payload self-consistency check, not a secret
verification gate. `internal/batch/aggregator.go`'s only other caller
passes a hardcoded constant with no attacker input at all.

Fixed it anyway: `VerifyZKProof` is exported and general-purpose, so
this is free, zero-behavior-change hardening that doesn't rely on
today's threat model holding for whatever calls it next.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/proofs/...` — all 15 tests pass, including the
      one asserting both roots appear in the error message (preserved
      exactly; only the comparison mechanism changed)
- [x] `go test ./internal/router/... ./cmd/federated-router/...` — all
      downstream callers still pass
- [x] `go test ./...` — full module, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)