### PR TITLE
fix: resolve the three doc-accuracy gaps flagged (not fixed) by PR #119

### DIFF
--- a/.github/workflows/in-toto-supply-chain.yml
+++ b/.github/workflows/in-toto-supply-chain.yml
@@ -160,35 +160,43 @@ jobs:
         id: record
         run: |
           mkdir -p /tmp/in-toto
-          
-          # Run formal proof verification
+
+          # Formal-proof verification is enforced as a dedicated, required
+          # CI gate (.github/workflows/verify-formal-proofs.yml) on every
+          # change touching proof files, before merge to main. It is not
+          # re-run here: this job has no Lean/Mathlib toolchain installed,
+          # and rebuilding the full proof suite (8000+ jobs) on every tagged
+          # release would add hours to the release pipeline without
+          # checking anything that wasn't already gated pre-merge.
           echo "=== Formal Proof Verification ===" >> /tmp/in-toto/verification.txt
-          make verify-formal-proofs >> /tmp/in-toto/verification.txt 2>&1 || true
-          
-          # Run Go tests
+          echo "Enforced pre-merge by .github/workflows/verify-formal-proofs.yml (not re-run here)" >> /tmp/in-toto/verification.txt
+
+          # Run Go tests. No "|| true": a failure here fails this job,
+          # which blocks generate-link-metadata and publish-in-toto-attestations
+          # via the needs: chain, so this is a real gate on the release.
           echo "=== Go Test Suite ===" >> /tmp/in-toto/verification.txt
-          ./scripts/go_with_toolchain.sh go test ./... -v >> /tmp/in-toto/verification.txt 2>&1 || true
-          
+          ./scripts/go_with_toolchain.sh go test ./... -v >> /tmp/in-toto/verification.txt 2>&1
+
           # Run Python tests
           echo "=== Python Test Suite ===" >> /tmp/in-toto/verification.txt
-          cd sdk/python && python -m pytest tests/ -v >> /tmp/in-toto/verification.txt 2>&1 || true
-          cd ../..
-          
+          (cd sdk/python && python -m pytest tests/ -v) >> /tmp/in-toto/verification.txt 2>&1
+
           # Security scanning
           echo "=== Security Scanning ===" >> /tmp/in-toto/verification.txt
           ./scripts/go_with_toolchain.sh go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
-          govulncheck ./... >> /tmp/in-toto/verification.txt 2>&1 || true
-          
+          govulncheck ./... >> /tmp/in-toto/verification.txt 2>&1
+
           # Verify checksums
           echo "=== Artifact Integrity ===" >> /tmp/in-toto/verification.txt
           echo "Build artifacts verified" >> /tmp/in-toto/verification.txt
-          
+
           RESULTS=$(cat /tmp/in-toto/verification.txt | base64 -w0)
           echo "results=${RESULTS}" >> $GITHUB_OUTPUT
-          
+
           cat /tmp/in-toto/verification.txt
 
       - name: Upload verification results
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: in-toto-verification

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Quick Links:
 - **[Performance](docs/performance/)** - Benchmarks, tuning, profiling
 - **[Archive](docs/archive/root-cleanup-2026-04/README.md)** - Historical root cleanup index and superseded docs
 - **[Examples](docs/examples/)** - PyTorch, TensorFlow, Flower integration
-- **[Phase 4](docs/PHASE_4_PRODUCTION_DEPLOYMENT.md)** - Production deployment guide
+- **[Phase 4](docs/PHASE_4_PRODUCTION_DEPLOYMENT.md)** - What's real vs. fabricated in the old "production deployment" doc
 
 
 See [docs/INDEX.md](docs/INDEX.md) for complete navigation and role-based quick links.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,13 +1,13 @@
 # Sovereign-Mohawk Documentation Index
 
 **Last Updated:** May 9, 2026  
-**Status:** Complete with Phase 4 Production Deployment
+**Status:** See [Documentation Status](#documentation-status) below for what's real vs. placeholder.
 
 ---
 
 ## Quick Navigation
 
-- **[Getting Started](GETTING_STARTED.md)** - Installation, quickstart, first steps
+- **[Getting Started](guides/GETTING_STARTED.md)** - Installation, quickstart, first steps (placeholder stub — see [Documentation Status](#documentation-status))
 - **[Architecture Guide](ARCHITECTURE.md)** - System design, component overview
 - **[API Reference](API_REFERENCE.md)** - Go packages, gRPC services, Python SDK
 - **[Deployment Guide](DEPLOYMENT.md)** - Docker, Kubernetes, Cloud deployment
@@ -36,18 +36,26 @@
 - [Routing & Topology](architecture/ROUTING_TOPOLOGY.md) - DAG consistency, failover
 
 ### Phase 4: Production Deployment
-- **[Production Deployment](PHASE_4_PRODUCTION_DEPLOYMENT.md)** - Docker, K8s, Cloud, operations
+- **[Production Deployment](PHASE_4_PRODUCTION_DEPLOYMENT.md)** - What's real vs. fabricated in the old deployment guide
 - [Performance Benchmarks](BENCHMARKS_AND_REPRODUCIBILITY.md) - Throughput, latency, tuning
-- [Post-Deployment Validation](guides/POST_DEPLOYMENT_VALIDATION.md) - Smoke tests, runbooks
+- [Post-Deployment Validation](guides/POST_DEPLOYMENT_VALIDATION.md) - Smoke tests, runbooks (placeholder stub)
 
 ---
 
 ## Core Documentation
 
+The trees below list only files that actually exist in this repo. Unless
+marked `(real)`, every listed file is a 5-line placeholder scaffold ("Scaffold
+document created to preserve canonical documentation links... See
+docs/INDEX.md") — see [Documentation Status](#documentation-status). A
+"Not created" line per section names what earlier versions of this index
+claimed existed but doesn't.
+
 ### Architecture & Design
 ```
 docs/architecture/
-├── BYZANTINE_RESILIENCE.md         - Multi-Krum, Byzantine tolerance
+├── README.md                        - (real) directory overview
+├── BYZANTINE_RESILIENCE.md          - Multi-Krum, Byzantine tolerance
 ├── DIFFERENTIAL_PRIVACY.md          - RDP, epsilon accounting
 ├── STREAMING_AGGREGATOR.md          - Hot-path ingestion, reassembly
 ├── TRANSPORT_LAYER.md               - MRC packet spraying
@@ -60,73 +68,74 @@ docs/architecture/
 ### Deployment & Operations
 ```
 docs/guides/
+├── README.md                        - (real) directory overview
 ├── GETTING_STARTED.md               - Installation, quickstart
 ├── DEPLOYMENT.md                    - Docker, K8s, Cloud templates
-├── DOCKER_DEPLOYMENT.md             - Docker Compose, image building
-├── KUBERNETES_DEPLOYMENT.md         - EKS, GKE, AKS setup
-├── CLOUD_DEPLOYMENT.md              - AWS, GCP, Azure templates
 ├── OPERATIONS.md                    - Monitoring, troubleshooting
 ├── MONITORING_OBSERVABILITY.md      - Prometheus, Grafana, Jaeger
 ├── TROUBLESHOOTING.md               - Common issues, solutions
 ├── POST_DEPLOYMENT_VALIDATION.md    - Smoke tests, validation matrix
 ├── SCALING_OPERATIONS.md            - Tier scaling, auto-scaling
-└── FAILOVER_RECOVERY.md             - Disaster recovery runbooks
+└── DEVELOPMENT.md                   - Development environment setup
 ```
+Not created: `DOCKER_DEPLOYMENT.md`, `KUBERNETES_DEPLOYMENT.md`,
+`CLOUD_DEPLOYMENT.md`, `FAILOVER_RECOVERY.md`.
 
 ### API & Integration
 ```
 docs/api/
+├── README.md                        - (real) directory overview
 ├── API_REFERENCE.md                 - Go packages, types, methods
-├── PYTHON_SDK_GUIDE.md              - Python SDK examples
-├── GRPC_SERVICES.md                 - Service definitions, endpoints
-├── WEBHOOK_INTEGRATION.md           - Event webhooks, callbacks
-├── REST_API.md                      - HTTP endpoints
-└── EXAMPLES.md                      - Code samples, patterns
+└── PYTHON_SDK_GUIDE.md              - Python SDK examples
 ```
+Not created: `GRPC_SERVICES.md`, `WEBHOOK_INTEGRATION.md`, `REST_API.md`,
+`EXAMPLES.md`.
 
 ### Security & Compliance
 ```
 docs/security/
+├── README.md                        - (real) directory overview
 ├── SECURITY.md                      - PQC, TPM, XMSS
 ├── COMPLIANCE.md                    - EU AI Act, regulatory alignment
 ├── THREAT_MODEL.md                  - Attack scenarios, mitigations
 ├── INCIDENT_RESPONSE.md             - Response procedures
-├── SUPPLY_CHAIN_SECURITY.md         - Artifact verification
-└── VULNERABILITY_DISCLOSURE.md      - Responsible disclosure
+└── SUPPLY_CHAIN_SECURITY.md         - Artifact verification
 ```
+Not created: `VULNERABILITY_DISCLOSURE.md`.
 
 ### Performance & Benchmarking
 ```
 docs/performance/
-├── BENCHMARKS_AND_REPRODUCIBILITY.md - Full benchmark suite
-├── PERFORMANCE_TUNING.md            - Parameter optimization
-├── LOAD_TESTING.md                  - Stress test scenarios
-├── PROFILING_GUIDE.md               - CPU, memory profiling
-├── RESOURCE_REQUIREMENTS.md         - Hardware recommendations
-└── PERFORMANCE_REGRESSION.md        - CI gates, thresholds
+├── README.md                        - (real) directory overview
+└── PERFORMANCE_TUNING.md            - Parameter optimization
 ```
+Not created: `LOAD_TESTING.md`, `PROFILING_GUIDE.md`,
+`RESOURCE_REQUIREMENTS.md`, `PERFORMANCE_REGRESSION.md`. The real benchmark
+entrypoint is [BENCHMARKS_AND_REPRODUCIBILITY.md](BENCHMARKS_AND_REPRODUCIBILITY.md)
+at the docs root, not under `performance/`.
 
 ### Formal Verification & Proofs
 ```
 docs/formal-verification/
+├── README.md                        - (real) directory overview
 ├── FORMAL_VERIFICATION_GUIDE.md     - Lean setup, verification
-├── THEOREM_SPECIFICATIONS.md        - 6 theorem claims
-├── PROOF_TRACEABILITY_MATRIX.md     - Claim → Proof → Runtime Evidence
-├── PROOF_CHECKLIST.md               - Lean verification checklist
-└── EXTENDING_PROOFS.md              - Adding new theorems
+└── THEOREM_SPECIFICATIONS.md        - 6 theorem claims
 ```
+Not created: `PROOF_TRACEABILITY_MATRIX.md` (see the real
+[proofs/FORMAL_TRACEABILITY_MATRIX.md](../proofs/FORMAL_TRACEABILITY_MATRIX.md)
+instead), `PROOF_CHECKLIST.md`, `EXTENDING_PROOFS.md`.
 
 ### Examples & Tutorials
 ```
 docs/examples/
-├── QUICKSTART_PYTORCH.md            - PyTorch federated learning
-├── QUICKSTART_TENSORFLOW.md         - TensorFlow federated learning
-├── FLOWER_INTEGRATION.md            - Flower framework integration
-├── CUSTOM_AGGREGATION.md            - Custom aggregation functions
-├── BYZANTINE_ATTACK_SIMULATION.md   - Intentional Byzantine nodes
-├── MONITORING_SETUP.md              - Full monitoring stack
-└── MULTI_CLOUD_DEPLOYMENT.md        - Cross-cloud federation
+├── README.md                        - (real) directory overview
+└── CUSTOM_AGGREGATION.md            - Custom aggregation functions
 ```
+Not created: `QUICKSTART_PYTORCH.md`, `QUICKSTART_TENSORFLOW.md`,
+`FLOWER_INTEGRATION.md` (there is a real, differently-named
+[docs/flower-integration.md](flower-integration.md) at the docs root),
+`BYZANTINE_ATTACK_SIMULATION.md`, `MONITORING_SETUP.md`,
+`MULTI_CLOUD_DEPLOYMENT.md`.
 
 ---
 
@@ -215,12 +224,20 @@ Only index and quick reference files:
 
 ## Documentation Status
 
-The "Complete ✅" checklist previously here overstated what exists -- a
-documentation audit found the 8 files under `docs/architecture/` are 5-line
-placeholder stubs ("Scaffold document created to preserve canonical
-documentation links... See docs/INDEX.md"), and most of the specific paths
-this index maps under `guides/`, `api/`, `security/`, `performance/`,
-`formal-verification/`, and `examples/` below do not exist in this repo.
+The "Complete ✅" checklist previously here overstated what exists. A
+documentation audit found two separate problems, both now corrected in this
+file:
+
+1. Most files this index links to under `docs/architecture/`, `guides/`,
+   `api/`, `security/`, `performance/`, `formal-verification/`, and
+   `examples/` do exist, but are 5-line placeholder scaffolds ("Scaffold
+   document created to preserve canonical documentation links... See
+   docs/INDEX.md") rather than real content -- each is marked in the trees
+   above unless tagged `(real)`.
+2. A meaningful minority of the files this index previously listed in those
+   same trees don't exist at all -- those have been removed from the trees
+   above and called out under a "Not created" line per section instead of
+   being silently dropped.
 
 What's actually real and worth trusting:
 - Formal proofs and specifications: real, see [proofs/FORMAL_TRACEABILITY_MATRIX.md](../proofs/FORMAL_TRACEABILITY_MATRIX.md) for the honest per-theorem scope.
@@ -247,14 +264,18 @@ not been re-audited past what's listed above.
 
 ### Adding New Documentation
 1. Place file in appropriate `docs/subdirectory/`
-2. Use template from `docs/CONTRIBUTING_DOCS.md`
-3. Cross-reference from relevant index page
-4. Submit PR with documentation changes
+2. Cross-reference from relevant index page
+3. Submit PR with documentation changes
+
+(There is no `docs/CONTRIBUTING_DOCS.md` template — an earlier version of
+this index referenced one that was never created.)
 
 ### Updating Existing Documentation
 1. Make changes in appropriate file
 2. Verify all cross-references still valid
-3. Run link checker: `make validate-docs-links`
+3. Run the link checker: `python3 scripts/ci/check_markdown_links.py`
+   (also runs as CI in `.github/workflows/markdown-link-check.yml` on every
+   PR)
 4. Submit PR with documentation changes
 
 ### Documentation Standards

--- a/docs/PHASE_4_PRODUCTION_DEPLOYMENT.md
+++ b/docs/PHASE_4_PRODUCTION_DEPLOYMENT.md
@@ -1,572 +1,105 @@
 # Phase 4: Production Deployment & Scale Validation
 
-**Status:** ✅ Complete  
-**Date:** May 9, 2026  
-**Scope:** End-to-end federation testing, performance validation, production deployment guidance
+**Status:** Partially real. This document previously described a complete,
+validated production deployment system (dedicated Docker Compose stack,
+Kubernetes manifests, AWS/GCP/Azure templates, operational runbook scripts,
+and specific throughput/latency numbers). None of that tooling exists in
+this repository. This page has been rewritten to describe only what's
+actually here and how to exercise it yourself.
+
+For the canonical, up-to-date version of this correction see the
+["Multi-Tier Transport & Federation"](../README.md#multi-tier-transport--federation-internal-packages)
+section of the root README — this page mirrors it.
 
 ---
 
-## Overview
+## What's real
 
-Phase 4 completes the Sovereign-Mohawk MRC implementation with production-ready deployment, end-to-end testing across the full hierarchy, and performance validation at scale.
+- **`internal/transport`** — the MRC (multi-path spraying) transport
+  adapter. `go test ./internal/transport/...` passes, including
+  `BenchmarkMRCThroughput`.
+- **`internal/streaming_aggregator.go`** — non-blocking chunk
+  reassembly/buffering for streaming gradient ingestion. `go test -run
+  TestStreamingAggregator ./internal/` passes (chunk reassembly,
+  out-of-order chunks, multi-tensor buffering, stale-buffer eviction,
+  overflow rejection), including `BenchmarkStreamingAggregatorIngest`.
+- **`internal/federation`** — a Regional → Continental → Global gRPC-based
+  aggregation hierarchy. `go test ./internal/federation/...` passes,
+  including a simulated 100-node scenario (`TestFederationScenario100Nodes`
+  in `internal/federation/federation_end_to_end_test.go`; there is no
+  `TestTwoTierFederation`/`TestThreeTierFederation` as an earlier version of
+  this doc claimed).
+- **Byzantine filtering:** Multi-Krum, with real tests
+  (`TestMultiKrumSelect`, `TestMultiKrumAggregate` in
+  `internal/multikrum*_test.go`) and exercised live via the Genesis Testnet
+  stack.
+- **Local multi-node deployment:** `./scripts/genesis-launch.sh
+  --all-nodes` brings up the full stack via the root `docker-compose.yml`
+  (orchestrator, 3 node-agents, federated-router, TPM metrics, Prometheus,
+  Grafana, Alertmanager, IPFS, ops-assistant) — see the
+  [Genesis Testnet section](../README.md#genesis-testnet) of the README for
+  the actual, runnable quickstart.
+- **Monitoring:** Prometheus + Grafana are real and wired up by the same
+  compose stack. Jaeger distributed tracing is not currently wired into the
+  default compose stack, despite being described below in an earlier
+  version of this doc.
+- **Cloud bootstrap scaffolds:** `deploy/cloud-templates/` has real
+  single-VM `aws-userdata.sh` / `gcp-startup.sh` scripts that install
+  Docker, clone the repo, and launch the baseline stack — see
+  [`deploy/cloud-templates/README.md`](../deploy/cloud-templates/README.md).
+  These are explicitly scaffolds for one-node evaluation, not a
+  multi-region production topology.
+- **Kubernetes:** a single-service Helm chart at
+  `helm/sovereign-mohawk/` (orchestrator deployment, RBAC, network policy).
+  There is no multi-tier StatefulSet topology, service mesh, or
+  Grafana/Loki monitoring stack manifest anywhere in this repo.
 
-**Key Deliverables:**
-- End-to-end federation integration tests (3-node, 10-node, 100-node scenarios)
-- Performance benchmarks and tuning guidance
-- Production deployment playbooks (Docker, Kubernetes, Cloud)
-- Monitoring and observability configuration
-- Post-deployment validation checklist
-- Operational runbooks and troubleshooting guide
+## What was fabricated in the previous version of this document
 
----
+- A dedicated `docker-compose.phase4-prod.yml`, `deploy/kubernetes/phase4-prod/`
+  (with 90 regional / 10 continental / 1 global replica StatefulSets, an
+  Istio service mesh, and a Prometheus+Grafana+Loki monitoring stack), and
+  AWS CloudFormation / GCP Terraform / Azure ARM templates for a
+  "phase4-prod-federation" topology — none of these paths exist.
+- `scripts/phase4/{health-check,validate-federation,test-byzantine-scenario,
+  measure-e2e-latency,stress-test-federation,isolate-nodes,reinstate-nodes,
+  validate-topology,validate-failover}.sh` — none of these scripts exist.
+- Specific numbers ("2,525 chunks/sec", "99.3% success rate", "160K+
+  ops/sec", "10K+ grad/sec", "<500ms TTL") were not backed by any benchmark
+  result file in this repo. A real (if informal) local
+  `go test -bench=BenchmarkMRCThroughput ./internal/transport` run measured
+  **17-40 ops/sec** — nowhere near the previously claimed figures. Treat any
+  specific throughput number as something to re-measure on your own
+  hardware, not a guaranteed target. See [PERFORMANCE.md](../PERFORMANCE.md)
+  for current methodology.
+- The "Production Readiness Checklist" and "Success Criteria" sections
+  claimed 16 items were all validated (Jaeger tracing enabled, failover
+  mechanisms validated, Kubernetes manifests prepared, etc.) — most of
+  these describe capabilities that don't exist in this repo, not completed
+  work.
+- The `TestTwoTierFederation` example test, and the "Byzantine Attack
+  Mitigation" / "Tier Scaling" / "Failover & Recovery" runbooks referencing
+  `kubectl patch`/`kubectl rollout`/`kubectl set` against resources this
+  repo has no manifests for, were illustrative pseudocode, not something
+  that runs against anything in this repository.
 
-## Architecture Integration
-
-### Deployment Topology
-
-```
-┌─────────────────────────────────────────────────────────┐
-│                    Global Aggregator                     │
-│              (Single Point of Consensus)                 │
-└─────┬─────────────────────────────┬─────────────────────┘
-      │                             │
-┌─────▼─────┐              ┌───────▼──────┐
-│Continental│              │Continental   │
-│Aggregator1│              │Aggregator 2  │
-└─────┬─────┘              └───────┬──────┘
-      │                           │
-  ┌───┴─────┬─────┐        ┌─────┴───┬─────┐
-  │   RR    │ RR  │        │  RR     │ RR  │
-  │Tier 1   │ 2-5 │        │Tier 4-7 │ 8-10│
-  └─────────┴─────┘        └─────────┴─────┘
-```
-
-**Tier Configuration:**
-- **Global (Level 3):** 1 node (federation root)
-- **Continental (Level 2):** 10 nodes (10:1 aggregation ratio)
-- **Regional (Level 1):** 100 nodes (10:1 aggregation ratio)
-
----
-
-## Phase 4 Implementation Checklist
-
-### A. End-to-End Integration Testing
-
-#### 1. Single-Tier Testing (✅ Complete - Phase 2)
-- [x] Streaming aggregator chunk assembly
-- [x] Out-of-order chunk reassembly
-- [x] Timeout-based batch flushing
-- [x] Byzantine filter integration hooks
-- [x] Metrics reporting
-
-**Test Command:**
-```bash
-go test -v ./internal -run "TestStreaming" -timeout 30s
-```
-
-#### 2. Two-Tier Federation Testing
-- [x] Regional aggregator accepting child gradients
-- [x] RPC forwarding to continental tier
-- [x] Continental aggregation and upward forwarding
-- [x] Health monitoring between tiers
-- [x] Exponential backoff on RPC failures
-
-**Test Command:**
-```bash
-go test -v ./internal/federation -timeout 30s
-```
-
-**Implementation:** Create `internal/federation/federation_integration_test.go`
-```go
-func TestTwoTierFederation(t *testing.T) {
-  // Regional → Continental tier integration
-  
-  // Start continental coordinator (parent)
-  continentalConfig := TierConfig{
-    TierID: "continental-1",
-    Level: TierContinental,
-    ChildNodeIDs: []string{"regional-1", "regional-2"},
-    MinQuorumSize: 2,
-    MaxBufferedGradients: 1000,
-  }
-  continent, _ := NewCoordinator(continentalConfig, "0.0.0.0:9091", "")
-  go continent.Start(ctx, "0.0.0.0:9091")
-  
-  // Start regional coordinators (children)
-  regionalConfig := TierConfig{
-    TierID: "regional-1",
-    Level: TierRegional,
-    ParentTierNodeID: "continental-1",
-    ChildNodeIDs: []string{},
-    MinQuorumSize: 5,
-    MaxBufferedGradients: 500,
-  }
-  regional, _ := NewCoordinator(regionalConfig, "0.0.0.0:9092", "continental-1:9091")
-  go regional.Start(ctx, "0.0.0.0:9092")
-  
-  // Generate gradients at regional tier
-  for i := 0; i < 10; i++ {
-    gradient := &GradientMessage{
-      GradientID: fmt.Sprintf("grad-%d", i),
-      Payload: make([]float64, 1000),
-    }
-    regional.ForwardGradient(ctx, gradient)
-  }
-  
-  // Verify aggregation at continental tier
-  stats := continent.Stats()
-  assert.Equal(t, stats["gradients_aggregated"], int64(10))
-}
-```
-
-#### 3. Three-Tier Full-Stack Testing
-- [x] Regional → Continental → Global federation
-- [x] Multi-hop gradient propagation
-- [x] Breadcrumb trail audit (PathHops)
-- [x] Global tier final aggregation
-- [x] End-to-end latency tracking
-
-**Test Command:**
-```bash
-go test -v ./internal/federation -run "TestThreeTierFederation" -timeout 60s
-```
-
----
-
-### B. Performance Benchmarking
-
-#### 1. Transport Layer Benchmark
-**Metric:** Chunks per second across multi-path spraying
+## Reproducing what's real
 
 ```bash
+# Full local multi-node stack (real)
+./scripts/genesis-launch.sh --all-nodes
+
+# Transport layer tests + benchmark (real)
+go test ./internal/transport/... -v
 go test -bench=BenchmarkMRCThroughput ./internal/transport -benchtime=10s
+
+# Streaming aggregator tests + benchmark (real)
+go test -run TestStreamingAggregator ./internal/ -v
+go test -bench=BenchmarkStreamingAggregatorIngest ./internal/ -benchtime=10s
+
+# Federation hierarchy tests, including a 100-node scenario (real)
+go test ./internal/federation/... -v
+
+# Byzantine (Multi-Krum) filtering tests (real)
+go test -run TestMultiKrum ./internal/ -v
 ```
-
-| Metric | Baseline | Target | Status |
-|--------|----------|--------|--------|
-| Throughput | 2,500 chunks/sec | 3,000+ chunks/sec | ✅ 2,525 |
-| Latency P95 | <50ms | <60ms | ✅ 50ms |
-| Latency P99 | <100ms | <120ms | ✅ 86ms |
-| Success Rate | >98% | >99% | ✅ 99.3% |
-
-#### 2. Streaming Aggregator Benchmark
-**Metric:** Chunk ingestion operations per second
-
-```bash
-go test -bench=BenchmarkStreamingAggregatorIngest ./internal -benchtime=10s
-```
-
-| Metric | Baseline | Target | Status |
-|--------|----------|--------|--------|
-| Throughput | 100K+ ops/sec | 150K+ ops/sec | ✅ 160K+ |
-| Per-op Latency | <10μs | <10μs | ✅ 7.4μs |
-| Buffered Tensors | 1000+ | 5000+ | ✅ 1000+ |
-| GC Pressure | <5% | <5% | ✅ Low |
-
-#### 3. Federation Tier Throughput
-**Metric:** Gradients per second through multi-tier hierarchy
-
-| Tier Jump | Throughput | Latency | Status |
-|-----------|-----------|---------|--------|
-| Child→Parent | 10K+ grad/sec | 50-200ms RPC | ✅ |
-| Batch Forward | 15K+ grad/sec | 30% improvement | ✅ |
-| Global Consensus | 1K+ grad/sec | <500ms TTL | ✅ |
-
----
-
-### C. Production Deployment Scenarios
-
-#### 1. Docker Compose Deployment
-
-**Scenario:** 3 Regional + 1 Continental node local cluster
-
-```bash
-docker-compose -f docker-compose.phase4-prod.yml up -d
-```
-
-**File:** `docker-compose.phase4-prod.yml`
-```yaml
-version: "3.8"
-
-services:
-  regional-aggregator-1:
-    image: sovereign-mohawk:latest
-    environment:
-      - TIER=regional
-      - TIER_ID=regional-1
-      - PARENT_ADDR=continental-aggregator:9091
-      - LISTEN_ADDR=0.0.0.0:9092
-    ports:
-      - "9092:9092"
-    networks:
-      - mohawk
-
-  regional-aggregator-2:
-    image: sovereign-mohawk:latest
-    environment:
-      - TIER=regional
-      - TIER_ID=regional-2
-      - PARENT_ADDR=continental-aggregator:9091
-      - LISTEN_ADDR=0.0.0.0:9093
-    networks:
-      - mohawk
-
-  continental-aggregator:
-    image: sovereign-mohawk:latest
-    environment:
-      - TIER=continental
-      - TIER_ID=continental-1
-      - LISTEN_ADDR=0.0.0.0:9091
-      - CHILDREN=regional-1,regional-2,regional-3
-    ports:
-      - "9091:9091"
-      - "9100:9100"  # Prometheus metrics
-    networks:
-      - mohawk
-
-  prometheus:
-    image: prom/prometheus:latest
-    volumes:
-      - ./monitoring/prometheus/prometheus-phase4.yml:/etc/prometheus/prometheus.yml
-    ports:
-      - "9101:9090"
-    networks:
-      - mohawk
-
-networks:
-  mohawk:
-    driver: bridge
-```
-
-#### 2. Kubernetes Deployment
-
-**Scenario:** Production-grade 100-node federation on EKS/GKE/AKS
-
-```bash
-kubectl apply -f deploy/kubernetes/phase4-prod/
-```
-
-**Components:**
-- `statefulset-regional.yml` - Regional tier aggregators (90 replicas)
-- `statefulset-continental.yml` - Continental tier aggregators (10 replicas)
-- `deployment-global.yml` - Global tier aggregator (1 replica)
-- `configmap-federation.yml` - Federation topology config
-- `service-mesh.yml` - Istio service mesh integration
-- `monitoring-stack.yml` - Prometheus + Grafana + Loki
-
-#### 3. Cloud Deployment Templates
-
-**AWS:**
-```bash
-deploy/cloud-templates/aws/phase4-prod-federation.yaml
-# CloudFormation for EKS with federation tier stack
-```
-
-**GCP:**
-```bash
-deploy/cloud-templates/gcp/phase4-prod-federation.tf
-# Terraform for GKE with managed Kubernetes
-```
-
-**Azure:**
-```bash
-deploy/cloud-templates/azure/phase4-prod-federation.json
-# ARM template for AKS deployment
-```
-
----
-
-### D. Monitoring & Observability
-
-#### 1. Prometheus Metrics
-
-**Transport Layer:**
-```promql
-# Multi-path spraying success rate
-rate(mohawk_transport_chunks_sent_total[5m])
-rate(mohawk_transport_chunks_success_total[5m])
-
-# Path scoring dynamics
-mohawk_transport_mrc_path_score{path_id}
-
-# Latency percentiles
-histogram_quantile(0.95, mohawk_transport_chunk_latency_seconds)
-```
-
-**Streaming Aggregator:**
-```promql
-# Ingestion throughput
-rate(mohawk_streaming_chunks_ingested_total[5m])
-
-# Buffer utilization
-mohawk_streaming_buffered_tensors_total
-
-# Assembly success rate
-rate(mohawk_streaming_tensors_ready_total[5m])
-```
-
-**Federation:**
-```promql
-# Tier-to-tier throughput
-rate(mohawk_federation_gradients_forwarded_total{tier}[5m])
-
-# RPC latency
-histogram_quantile(0.99, mohawk_federation_rpc_latency_seconds)
-
-# Byzantine filtering
-rate(mohawk_federation_gradients_filtered_total[5m])
-```
-
-#### 2. Grafana Dashboards
-
-**Dashboard 1: Transport Layer Health**
-- Multi-path spraying status
-- Path score evolution
-- Chunk latency distribution
-- Packet loss by path
-
-**Dashboard 2: Aggregation Pipeline**
-- Streaming ingestion rate
-- Chunk assembly buffer depth
-- Byzantine filtering effectiveness
-- Mean aggregation latency
-
-**Dashboard 3: Federation Hierarchy**
-- Cross-tier throughput
-- RPC success rates
-- Parent-child link health
-- Global aggregation time
-
-**Dashboard 4: Resource Utilization**
-- CPU per tier
-- Memory buffer pressure
-- Network bandwidth
-- Goroutine count
-
-#### 3. Distributed Tracing (Jaeger)
-
-**Trace Instrumentation:**
-```go
-// Chunk ingestion trace
-span := tracer.StartSpan("streaming_ingest_chunk",
-  ext.SpanKindRPCServer,
-  ext.HTTPUrl("chunk_id=" + chunk.ID),
-)
-
-// Federation RPC trace
-span := tracer.StartSpan("federation_forward_gradient",
-  ext.SpanKindRPCClient,
-  ext.HTTPStatusCode(200),
-)
-```
-
----
-
-### E. Post-Deployment Validation
-
-#### Smoke Tests
-
-```bash
-# 1. Check all tiers are healthy and responding
-./scripts/phase4/health-check.sh
-
-# 2. Validate federation routing
-./scripts/phase4/validate-federation.sh
-
-# 3. Run Byzantine resilience scenario
-./scripts/phase4/test-byzantine-scenario.sh
-
-# 4. Measure end-to-end latency
-./scripts/phase4/measure-e2e-latency.sh
-
-# 5. Stress test with simulated clients
-./scripts/phase4/stress-test-federation.sh --nodes=100
-```
-
-#### Validation Matrix
-
-| Test | Command | Expected | Status |
-|------|---------|----------|--------|
-| Health Check | `POST http://regional-1:9092/health` | `200 OK` | ✅ |
-| Federation Routing | `GET http://continental:9091/topology` | Consistent DAG | ✅ |
-| Gradient Flow | POST gradient to regional → verify at global | <500ms TTL | ✅ |
-| Byzantine Scenario | Send 33% faulty gradients | Filtered correctly | ✅ |
-| Throughput Validation | 100K gradient/sec sustained | No queuing | ✅ |
-
----
-
-### F. Operational Runbooks
-
-#### Runbook 1: Tier Scaling
-
-**Scenario:** Add 10 new regional aggregators at runtime
-
-```bash
-# Update federation topology config
-kubectl patch configmap federation-topology --type merge \
-  -p '{"data":{"new_regional_nodes":"regional-11,regional-12,...,regional-20"}}'
-
-# Trigger rolling update of regional tier
-kubectl rollout restart statefulset/regional-aggregators
-
-# Validate new nodes joined
-./scripts/phase4/validate-topology.sh
-```
-
-#### Runbook 2: Failover & Recovery
-
-**Scenario:** Continental aggregator failure → automatic reroute
-
-```bash
-# Detect failure (automated via Prometheus alerting)
-# Alert: FederationTierDown{tier="continental-1"}
-
-# Trigger failover to standby
-kubectl set pod pod-selector=tier=continental,failover=standby
-
-# Regional nodes re-register with backup continental aggregator
-# (automatic via gossip heartbeat detection in <5s)
-
-# Validate rerouting complete
-./scripts/phase4/validate-failover.sh
-```
-
-#### Runbook 3: Byzantine Attack Mitigation
-
-**Scenario:** Detected 33%+ gradient anomaly at continental tier
-
-```bash
-# 1. Isolate suspicious regional nodes
-./scripts/phase4/isolate-nodes.sh \
-  --nodes="regional-5,regional-12,regional-18" \
-  --reason="Byzantine anomaly"
-
-# 2. Increase Multi-Krum Byzantine parameters
-kubectl set env daemonset/regional-aggregators \
-  BYZANTINE_F=0.4
-
-# 3. Verify Byzantine filtering active
-curl http://continental:9091/metrics | grep byzantine_filter
-
-# 4. Reinstate nodes after manual inspection
-./scripts/phase4/reinstate-nodes.sh --nodes="regional-5,regional-12,regional-18"
-```
-
----
-
-### G. Performance Tuning Guide
-
-#### Parameter Tuning
-
-| Parameter | Default | Low Latency | High Throughput |
-|-----------|---------|-------------|-----------------|
-| `ChunkTimeout` | 500ms | 100ms | 1000ms |
-| `MaxBufferSize` | 1000 | 100 | 5000 |
-| `NumPaths` | 4 | 2 | 8 |
-| `BatchSize` | 100 | 10 | 1000 |
-
-#### Tuning Decision Tree
-
-```
-START
-│
-├─ Latency too high?
-│  ├─ YES → Reduce ChunkTimeout, reduce MaxBufferSize
-│  └─ NO → Continue
-│
-├─ Throughput too low?
-│  ├─ YES → Increase BatchSize, increase NumPaths
-│  └─ NO → Continue
-│
-├─ Memory pressure high?
-│  ├─ YES → Reduce MaxBufferSize, reduce BatchSize
-│  └─ NO → Continue
-│
-├─ Byzantine attacks detected?
-│  └─ YES → Increase Byzantine F parameter, add monitoring
-│
-└─ Stable → Done
-```
-
----
-
-### H. Production Readiness Checklist
-
-- [x] All unit tests passing (9/9)
-- [x] Transport layer benchmarked (2,525 chunks/sec)
-- [x] Streaming aggregator benchmarked (160K+ ops/sec)
-- [x] Federation integration tested (end-to-end)
-- [x] Docker deployment validated
-- [x] Kubernetes manifests prepared
-- [x] Prometheus metrics instrumented
-- [x] Grafana dashboards created
-- [x] Jaeger tracing enabled
-- [x] Runbooks documented
-- [x] Health check endpoints implemented
-- [x] Byzantine scenario tested
-- [x] Failover mechanisms validated
-- [x] Performance tuning guide provided
-- [x] Operational documentation complete
-- [x] Pre-flight checklist prepared
-
----
-
-## Deployment Checklist Template
-
-### Pre-Deployment
-
-```
-☐ Confirm all tests passing
-☐ Review resource requirements
-☐ Verify network connectivity
-☐ Check certificate validity
-☐ Validate configuration files
-☐ Backup existing deployment (if applicable)
-```
-
-### Deployment
-
-```
-☐ Stage container images
-☐ Deploy monitoring stack first (Prometheus, Grafana)
-☐ Deploy global tier
-☐ Deploy continental tier (wait for global ready)
-☐ Deploy regional tier (wait for continental ready)
-☐ Verify tier registration (topology DAG consistency)
-```
-
-### Post-Deployment
-
-```
-☐ Run smoke tests
-☐ Validate end-to-end gradient flow
-☐ Check Byzantine filtering active
-☐ Monitor throughput (should stabilize within 2m)
-☐ Verify all metrics in Prometheus
-☐ Test failover scenario
-☐ Document any deviations
-```
-
----
-
-## Success Criteria
-
-✅ **Phase 4 Complete When:**
-1. End-to-end federation tests passing on 100-node topology
-2. Performance benchmarks meet targets (160K+ ops/sec streaming)
-3. Production deployment processes validated (Docker, K8s, Cloud)
-4. Monitoring stack fully instrumented and dashboards operational
-5. Runbooks tested and documented
-6. All operational procedures automated
-7. Ready for production deployment
-
----
-
-## Next Steps (Post-Phase 4)
-
-1. **Production Launch:** Deploy 1000-node mainnet
-2. **Performance Optimization:** Tune Byzantine threshold based on live data
-3. **Auto-scaling:** Implement dynamic tier scaling based on load
-4. **Cross-region:** Extend federation to global multi-region deployment
-5. **Formal Audit:** Independent security audit of production deployment
-

--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -73,18 +73,35 @@ Binaries → Verification Step
 Test Results → Release Publishing
 ```
 
-### 4. Expanded Formal Verification Coverage
+### 4. What Actually Gates the Attestation
 
-Build attestations now include execution of our formal proof verification suite:
+The `verification-step` job in `in-toto-supply-chain.yml` runs the Go test
+suite, the Python SDK test suite, and `govulncheck`, and **must pass** for
+the release to proceed — `generate-link-metadata` and
+`publish-in-toto-attestations` both depend on this job via `needs:`, so a
+real failure here blocks publication. (Previously each of these commands
+was piped through `|| true`, which meant the job always reported success
+regardless of whether tests or the vulnerability scan actually passed —
+this has been fixed.)
 
-#### Included Verifications:
-- ✅ Lean theorem proofs (Theorems 1-6)
-- ✅ Go cryptographic implementations
-- ✅ Python SDK security properties
-- ✅ BFT consensus protocol correctness
-- ✅ Zero-knowledge proof validation
+#### Actually checked before an attestation is published:
+- ✅ Go test suite (`go test ./...`)
+- ✅ Python SDK test suite (`pytest sdk/python/tests/`)
+- ✅ Go vulnerability scan (`govulncheck ./...`)
 
-Each build must pass all formal verification checks before attestations are published.
+#### Not re-checked at tag time:
+- **Lean theorem proofs** — enforced as a separate, required CI gate
+  (`.github/workflows/verify-formal-proofs.yml`) on every change that
+  touches proof files, before merge to `main`. This job has no
+  Lean/Mathlib toolchain installed and does not re-run the proof suite;
+  rebuilding it (8000+ jobs) on every tagged release would add hours to
+  the release pipeline without checking anything new. See
+  [proofs/FORMAL_TRACEABILITY_MATRIX.md](../proofs/FORMAL_TRACEABILITY_MATRIX.md)
+  for the honest per-theorem scope of what's actually proven.
+- **"Zero-knowledge proof validation"** — there is no ZK-SNARK verifier in
+  this repo; `internal/proofs/verifier.go` does real signature/hash
+  verification, not zero-knowledge proof verification. See
+  [proofs/FORMAL_TRACEABILITY_MATRIX.md](../proofs/FORMAL_TRACEABILITY_MATRIX.md).
 
 ## Verification Instructions
 
@@ -220,7 +237,8 @@ in-toto-verify --layout layout.json --link-dir . --step material
 - [ ] SHA256SUMS file signed and verified
 - [ ] SLSA provenance v1.0 present in release
 - [ ] In-toto layout and link metadata present
-- [ ] All test suites passed (Go, Python, formal proofs)
+- [ ] Go and Python test suites passed (gates attestation publish; formal
+      proofs are gated separately, pre-merge, by `verify-formal-proofs.yml`)
 - [ ] No security vulnerabilities in govulncheck scan
 - [ ] Image digests match manifest references
 

--- a/web/ops-assistant/package-lock.json
+++ b/web/ops-assistant/package-lock.json
@@ -12222,9 +12222,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",


### PR DESCRIPTION
## Summary

PR #119's own test plan explicitly flagged three items as **found but not fixed**. This PR closes all three out.

1. **`docs/PHASE_4_PRODUCTION_DEPLOYMENT.md`** still described a complete, validated production deployment system (dedicated Docker Compose stack, K8s manifests, cloud templates, runbook scripts, specific throughput numbers) that doesn't exist in this repo. README.md's near-identical section was already corrected in PR #119, but this standalone doc was missed. Rewritten to mirror the README's corrected content: what's real (`internal/transport`, `streaming_aggregator`, `internal/federation`, the Genesis Testnet compose stack, the Helm chart, cloud-init scaffolds) vs. fabricated.
2. **`docs/INDEX.md`** linked ~20 files under `guides/`, `api/`, `security/`, `performance/`, `formal-verification/`, and `examples/` that don't exist anywhere in this repo, plus a dead `docs/CONTRIBUTING_DOCS.md` reference and a nonexistent `make validate-docs-links` target. Trimmed the directory-tree listings to only real files, added explicit "Not created" notes instead of silently dropping entries, fixed the top-nav Getting Started link, and pointed the link-checker instructions at the real script (`scripts/ci/check_markdown_links.py`).
3. **`docs/SUPPLY_CHAIN_SECURITY.md`** claimed every build must pass formal verification, Go tests, Python tests, and a vulnerability scan before attestations publish — but `in-toto-supply-chain.yml` piped all four checks through `|| true`, so the gate never actually gated anything. Removed `|| true` from the Go test / pytest / govulncheck steps (a real failure now fails the job and blocks the downstream `needs:` chain to `generate-link-metadata` and `publish-in-toto-attestations`). Left the formal-proof re-run removed rather than faked: this job has no Lean/Mathlib toolchain, so the command could never have succeeded here; proof verification is already a separate required pre-merge gate (`verify-formal-proofs.yml`). Corrected the doc to describe what actually gates the release vs. what's enforced elsewhere.

## Test plan

- [x] `python3 scripts/ci/check_markdown_links.py` — passes (166 files)
- [x] `python3 scripts/ci/lint_formal_proof_claims.py` — passes
- [x] `in-toto-supply-chain.yml` parses cleanly as YAML (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- Not independently re-run in CI: the `in-toto-supply-chain.yml` job itself only triggers on tag pushes / manual dispatch, so the now-real Go/Python/govulncheck gate hasn't been exercised end-to-end in this PR — reviewed the logic (needs: chain, no more `|| true`) but flagging that it's untested against an actual tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)