### PR TITLE
fix(branch-protection): correct stale required_status_checks contexts

### DIFF
--- a/scripts/apply_branch_protection.sh
+++ b/scripts/apply_branch_protection.sh
@@ -9,6 +9,12 @@ BRANCH="${BRANCH:-main}"
 # Example:
 #   export GITHUB_TOKEN=ghp_xxx
 #   bash scripts/apply_branch_protection.sh
+#
+# Note: "Bridge Compression Benchmark / bridge-regression-compare" was removed
+# from the contexts below. The entire bridge feature (including the
+# bridge-compression-benchmark.yml workflow that produced this check) was
+# deleted in d7deb9682 ("Remove bridge surfaces and refresh validation
+# artifacts"), so no job by this name can ever report back to GitHub.
 
 PAYLOAD=$(cat <<'JSON'
 {
@@ -19,11 +25,10 @@ PAYLOAD=$(cat <<'JSON'
       "Go Test / go-test",
       "Integrity Guard - Linter / lint",
       "Mainnet Readiness Gate / readiness-gate",
-      "Mainnet Chaos Gate / chaos-matrix",
+      "Mainnet Chaos Gate / chaos-gate",
       "Performance Gate / performance-gate",
       "Monitoring Smoke Gate / monitoring-smoke",
       "Release Performance Evidence / release-performance-evidence",
-      "Bridge Compression Benchmark / bridge-regression-compare",
       "FedAvg Benchmark Compare / fedavg-benchmark-compare",
       "Proof-Driven Design Verification / proof-audit",
       "Proof-Driven Design Verification / verify-lean-formalization",


### PR DESCRIPTION
## Summary
- `"Mainnet Chaos Gate / chaos-matrix"` → `"Mainnet Chaos Gate / chaos-gate"`: the job in `.github/workflows/mainnet-chaos-gate.yml` has always been named `chaos-gate`. `git log -S "chaos-matrix"` against `.github/workflows/` turns up nothing — `chaos-matrix` never existed under that name, even at the workflow's first commit (3ae765363). This looks like a typo introduced when the entry was authored in 0f652dc42.
- Removed `"Bridge Compression Benchmark / bridge-regression-compare"`: the entire bridge feature — including `.github/workflows/bridge-compression-benchmark.yml`, which produced this check — was deleted in d7deb9682 ("Remove bridge surfaces and refresh validation artifacts"). The context was valid at one point (it even got renamed from `bridge-compression-benchmark` to `bridge-regression-compare` in 074feb7f7 to track a workflow job rename), but nothing can ever satisfy it now that the workflow is gone. Documented the removal reason in a comment above the payload since JSON doesn't support inline comments.

Both corrected/verified entries were cross-checked against real, currently-existing workflow `name:` / job-id pairs, the same way `"Proof-Driven Design Verification / verify-links"` and `"Proof-Driven Design Verification / verify-lean-formalization"` map to real jobs in `.github/workflows/verify-proofs.yml`.

Out of scope: the `"Proof-Driven Design Verification / proof-audit"` entry in the same list is also stale (no `proof-audit` job exists), but per the task that's already being handled in a separate PR, so it's left untouched here.

This script is not invoked by any CI workflow, so there's nothing to run — verification was via `git log -S` history search plus manually re-parsing the embedded JSON payload with `python3 -m json.tool` to confirm it's still valid. Not run against the live repo; applying branch-protection settings needs the repo owner's explicit sign-off.

## Test plan
- [x] Confirmed `chaos-gate` is the only job id ever defined in `.github/workflows/mainnet-chaos-gate.yml` (git log -S)
- [x] Confirmed `bridge-compression-benchmark.yml` (and the whole bridge feature) was deleted in d7deb9682, so no workflow can produce a `Bridge Compression Benchmark` check
- [x] Re-parsed the embedded JSON payload to confirm it's still syntactically valid after edits
- [ ] Not run: `scripts/apply_branch_protection.sh` itself (requires repo-admin `GITHUB_TOKEN` and repo-owner sign-off — intentionally out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)