### PR TITLE
feat(governance): make the required CI gate actually verify Lean proofs

### DIFF
--- a/.github/workflows/full-validation-pr-gate.yml
+++ b/.github/workflows/full-validation-pr-gate.yml
@@ -8,6 +8,7 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   GOTOOLCHAIN: go1.26.5+auto
+  MATHLIB_CACHE_DIR: ${{ github.workspace }}/proofs/.lake/mathlib-cache
 
 jobs:
   full-validation-fast:
@@ -27,6 +28,81 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: '3.12'
+
+      # This is a required status check (branches/main/protection), unlike
+      # "Proof-Driven Design Verification / verify-lean-formalization" and
+      # "Verify Formal Proofs / verify-lean-formalizations", neither of
+      # which is required. Before this, the required gate validated that
+      # proofs/FORMAL_TRACEABILITY_MATRIX.md's cross-references were
+      # internally consistent (theorem/test symbol names existing somewhere
+      # in the tree) but never actually compiled the Lean proofs or ran the
+      # vacuous/misleading-theorem lint -- a PR could introduce a new sorry,
+      # a new vacuous theorem, or a Lean file that doesn't even compile, and
+      # merge to main cleanly. The "Build Lean formal theorem suite" and
+      # "Lint formal proof claims" steps below close that gap by running
+      # the same real checks verify-lean-formalization already runs,
+      # directly in the required job instead of a non-required sibling
+      # (the cache/toolchain steps around them are plumbing copied from
+      # that job to make the build/lint steps possible here).
+      - name: Free up disk space (critical for Mathlib)
+        # Deliberately does NOT remove $AGENT_TOOLSDIRECTORY, unlike the
+        # otherwise-identical step in verify-proofs.yml: this job (unlike
+        # that one) already ran actions/setup-go and actions/setup-python
+        # above and also builds/tests Go code later in the same job, so
+        # clearing the tool cache here risks breaking those later steps.
+        run: |
+          df -h
+          echo "Cleaning up runner..."
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/lib/jvm /usr/local/.ghcup /usr/share/swift /usr/local/share/powershell
+          sudo docker image prune -a -f || true
+          sudo docker builder prune -a -f || true
+          df -h
+
+      - name: Restore Lean/Lake cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: |
+            proofs/.lake/packages
+            proofs/.lake/build
+          key: lean-lake-${{ runner.os }}-${{ hashFiles('proofs/lean-toolchain', 'proofs/lakefile.lean', 'proofs/lake-manifest.json') }}
+          restore-keys: |
+            lean-lake-${{ runner.os }}-
+
+      - name: Install elan
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: Fetch prebuilt Mathlib cache
+        working-directory: proofs
+        run: |
+          lake update
+          lake exe cache get
+
+      - name: Build Lean formal theorem suite
+        working-directory: proofs
+        run: |
+          lake build LeanFormalization
+          lake build Specification
+          lake build Refinement
+          echo "All formal theorems compiled successfully."
+
+      - name: Lint formal proof claims (vacuous/misleading theorem scan)
+        run: python3 scripts/ci/lint_formal_proof_claims.py --repo-root .
+
+      - name: Cleanup transient Mathlib cache
+        if: always()
+        run: rm -rf "$MATHLIB_CACHE_DIR" || true
+
+      - name: Save Lean/Lake cache
+        if: always()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: |
+            proofs/.lake/packages
+            proofs/.lake/build
+          key: lean-lake-${{ runner.os }}-${{ hashFiles('proofs/lean-toolchain', 'proofs/lakefile.lean', 'proofs/lake-manifest.json') }}
 
       - name: Validate formal report consistency and bundle integrity
         run: |

--- a/README.md
+++ b/README.md
@@ -80,12 +80,13 @@ Adoption execution tracker (30/60/90): [docs/ADOPTION_ACCELERATION_PLAN.md](docs
 
 - Lean source of truth: [proofs/LeanFormalization.lean](proofs/LeanFormalization.lean)
 - Theorem modules: [proofs/LeanFormalization/](proofs/LeanFormalization/)
-- **Traceability matrix** (theorem claim → Lean module → runtime test evidence → status): [proofs/FORMAL_TRACEABILITY_MATRIX.md](proofs/FORMAL_TRACEABILITY_MATRIX.md) — _start here first; it tracks 11 claims, each with its own status (`fully_formalized`, `surrogate_verified_*`, `model_verified`, or `Phase 4 model`) and, where relevant, an explicit note on what is **not** yet proven. Read the Notes column, not just the Status column — several entries carry caveats that qualify the headline status._
+- **Traceability matrix** (theorem claim → Lean module → runtime test evidence → status): [proofs/FORMAL_TRACEABILITY_MATRIX.md](proofs/FORMAL_TRACEABILITY_MATRIX.md) — _start here first; it tracks 15 claims, each with its own status (`fully_formalized`, `surrogate_verified_*`, `model_verified`, or `Phase 4 model`) and, where relevant, an explicit note on what is **not** yet proven. Read the Notes column, not just the Status column — several entries carry caveats that qualify the headline status._
 - Machine-checkable formal validation report: [results/proofs/formal_validation_report.json](results/proofs/formal_validation_report.json)
 - Verification bundle manifest + archive: [results/proofs/formal-verification-bundle/bundle_manifest.json](results/proofs/formal-verification-bundle/bundle_manifest.json), [results/proofs/formal-verification-bundle.tar.gz](results/proofs/formal-verification-bundle.tar.gz)
 - Independent verifier guide: [docs/FORMAL_VERIFICATION_GUIDE.md](docs/FORMAL_VERIFICATION_GUIDE.md)
-- CI formal proof gates: [.github/workflows/verify-proofs.yml](.github/workflows/verify-proofs.yml) (`verify-lean-formalization`), [.github/workflows/verify-formal-proofs.yml](.github/workflows/verify-formal-proofs.yml)
-- Mathlib disk-space safeguard in CI: both workflows run pre-build runner cleanup before Lean/Lake build steps
+- **Required** CI formal proof gate (blocks merge to `main`): [.github/workflows/full-validation-pr-gate.yml](.github/workflows/full-validation-pr-gate.yml) (`full-validation-fast`, which builds the full Lean suite and runs the vacuous-theorem lint)
+- Additional, non-required Lean workflows (same checks plus artifact/bundle generation, run for visibility but do not block merge): [.github/workflows/verify-proofs.yml](.github/workflows/verify-proofs.yml) (`verify-lean-formalization`), [.github/workflows/verify-formal-proofs.yml](.github/workflows/verify-formal-proofs.yml)
+- Mathlib disk-space safeguard in CI: all three jobs above run pre-build runner cleanup before Lean/Lake build steps
 - Latest local verification log (build + placeholder scan): [proofs/manual_verify.log](proofs/manual_verify.log)
 
 

--- a/docs/SUPPLY_CHAIN_SECURITY.md
+++ b/docs/SUPPLY_CHAIN_SECURITY.md
@@ -90,12 +90,20 @@ this has been fixed.)
 - ✅ Go vulnerability scan (`govulncheck ./...`)
 
 #### Not re-checked at tag time:
-- **Lean theorem proofs** — enforced as a separate, required CI gate
-  (`.github/workflows/verify-formal-proofs.yml`) on every change that
-  touches proof files, before merge to `main`. This job has no
-  Lean/Mathlib toolchain installed and does not re-run the proof suite;
-  rebuilding it (8000+ jobs) on every tagged release would add hours to
-  the release pipeline without checking anything new. See
+- **Lean theorem proofs** — enforced as part of the `full-validation-fast`
+  required status check (`.github/workflows/full-validation-pr-gate.yml`),
+  which compiles the whole Lean theorem suite (`lake build`) and runs the
+  vacuous/misleading-theorem lint on every PR before merge to `main`. (Two
+  earlier, more detailed Lean workflows,
+  `.github/workflows/verify-formal-proofs.yml` and
+  `.github/workflows/verify-proofs.yml`, run the same checks plus
+  additional artifact/bundle generation, but neither is itself a required
+  status check — this line previously claimed `verify-formal-proofs.yml`
+  was, which was inaccurate; nothing there was actually gating merges
+  until `full-validation-fast` picked up the build+lint steps.) This job
+  has no need to run again on every tagged release — rebuilding the full
+  suite (8000+ jobs) would add hours to the release pipeline without
+  checking anything not already checked pre-merge. See
   [proofs/FORMAL_TRACEABILITY_MATRIX.md](../proofs/FORMAL_TRACEABILITY_MATRIX.md)
   for the honest per-theorem scope of what's actually proven.
 - **"Zero-knowledge proof validation"** — there is no ZK-SNARK verifier in
@@ -238,7 +246,8 @@ in-toto-verify --layout layout.json --link-dir . --step material
 - [ ] SLSA provenance v1.0 present in release
 - [ ] In-toto layout and link metadata present
 - [ ] Go and Python test suites passed (gates attestation publish; formal
-      proofs are gated separately, pre-merge, by `verify-formal-proofs.yml`)
+      proofs are gated separately, pre-merge, by the required
+      `full-validation-fast` status check)
 - [ ] No security vulnerabilities in govulncheck scan
 - [ ] Image digests match manifest references
 

--- a/proofs/FORMAL_TRACEABILITY_MATRIX.md
+++ b/proofs/FORMAL_TRACEABILITY_MATRIX.md
@@ -92,20 +92,45 @@ This matrix is designed for automated extraction:
 - Regenerate artifacts: `make refresh-formal-validation`
 - Validate report and bundle integrity: `make validate-formal`
 
+## CI Enforcement (Phase 4)
+
+This matrix and its underlying `lake build`/lint checks are only as trustworthy
+as the CI gate that runs them on every change. As of 2026-08-04, that gate is
+real: the **required** `full-validation-fast` status check
+(`.github/workflows/full-validation-pr-gate.yml`) compiles the whole Lean
+theorem suite (`lake build LeanFormalization Specification Refinement`) and
+runs `scripts/ci/lint_formal_proof_claims.py` (the vacuous/misleading-theorem
+lint) before a PR can merge to `main`, in addition to the
+`validate_formal_traceability.sh` cross-reference check it already ran.
+
+This closes a real, previously undocumented gap: before this, the only Lean-
+aware *required* check validated that this matrix's cited theorem/test symbol
+names existed somewhere in the tree — not that the underlying Lean code
+compiled, or that it was free of vacuous/misleading theorems. A PR could have
+introduced a new `sorry`, a new vacuous theorem, or a Lean file that didn't
+even compile, and merged to `main` cleanly; the actual build+lint checks only
+ran in the non-required `verify-lean-formalization` (`verify-proofs.yml`) and
+`verify-lean-formalizations` (`verify-formal-proofs.yml`) workflows.
+`docs/SUPPLY_CHAIN_SECURITY.md` had previously (incorrectly) documented
+`verify-formal-proofs.yml` itself as "enforced as a separate, required CI
+gate" — it wasn't; that claim has been corrected alongside this fix.
+
+`scripts/apply_branch_protection.sh` — an admin-only helper for setting the
+full desired branch-protection state, never itself run automatically — also
+had a stale required-context entry, `Proof-Driven Design Verification /
+proof-audit`, referencing a job that was never actually created under that
+name (fixed to `verify-links`, the real job in that workflow); two further
+stale entries unrelated to formal verification (`chaos-matrix` →
+`chaos-gate`, and a "Capability Sync" workflow/job name mismatch) were found
+and fixed in the same pass, and one (`Bridge Compression Benchmark`) remains
+open, flagged separately.
+
 ## Latest Validation Run
 
 - Date (UTC): 2026-08-04
-- Branch: `fix/orphaned-rdp-scaffolding` (merged with `main`, which had
-  already merged `feat/phase3-bft-probabilistic-composition`,
-  `fix/rdp-sequential-composition`, `feat/ledger-go-refinement`,
-  `feat/transport-go-refinement`, `feat/rdpaccountant-go-refinement`,
-  `feat/multikrum-go-refinement`, `fix/theorem5-6-crypto-convergence`,
-  `fix/theorem4-liveness-measure-theory`, `fix/theorem7-8-pqc-hardness`,
-  `fix/theorem2-rdp-sorries`, `fix/theorem1-bft-compositional`, and
-  `feat/formal-verification-phase0` — removes two Lean files that were
-  compiled into the main build but never referenced anywhere in this matrix
-  or `theorem_claims.json`, the same "compiled but unclaimed" pattern
-  `Refinement/Transport.lean` turned out to hide before it was fixed)
+- Branch: `feat/phase4-gate-real-lean-verification` (off `main`, which had
+  already merged all prior Phase 0-3 work; first Phase 4 (Governance/Audit)
+  deliverable — see "CI Enforcement (Phase 4)" above for the substance)
 - Commands executed:
   - `cd proofs && lake build LeanFormalization Specification Refinement` — 8340 jobs
   - `python3 scripts/ci/lint_formal_proof_claims.py --repo-root .`
@@ -115,40 +140,27 @@ This matrix is designed for automated extraction:
   - `python3 scripts/ci/check_markdown_links.py`
   - `python3 scripts/check_refinement.py --lean proofs/Specification/System.lean --go internal/ --json`
 - Results:
-  - This run reconciles two independent pieces of work now both on `main`:
-    Phase 3's BFT probabilistic-composition additions to row 1 (`binomial_mean`,
-    `binomial_markov`, `probabilistic_hierarchical_bound`), and this branch's
-    own removal of two orphaned Lean files, `Theorem2RDP_Enhanced.lean` and
-    `Theorem2AdvancedRDP.lean` (deliberately not written as
-    `LeanFormalization/Theorem2....lean` paths here — that exact pattern is
-    what this script's own module-detection regex, see below, scans for, and
-    these files are gone, not a live claim). The first's
-    `RDPEnhanced.composeEpsRat`/`convertToEpsDelta` were byte-for-byte
-    duplicates of definitions already real and claimed in `Theorem2RDP.lean`,
-    just under a different namespace — dead code, no unique content lost.
-    The second's `Advanced.subsampling_eps_le`/
-    `subsampling_amplification_factor_rational` were real, non-vacuous, but
-    misleadingly named: "subsampling amplification" is a specific,
-    well-known, nontrivial differential-privacy result, but what was
-    actually proven — `eps*p ≤ eps` and `p*k ≤ k` for `p≤1` — is unconnected
-    pure arithmetic, the same "name/docstring overclaims what the statement
-    establishes" pattern already found and fixed elsewhere this session,
-    e.g. `Theorem5Cryptography.lean`'s renamed `theorem5_verifyops_constant`.
-    Removed both files' import lines from `LeanFormalization.lean` rather
-    than leaving orphaned imports.
-  - Lean build: pass, 8340 jobs (down from 8342, matching the two removed
-    files); **zero `sorry`s remain in `proofs/LeanFormalization`**
-    (unaffected by either piece of work this run reconciles)
-  - Vacuous/misleading-theorem lint: pass (`22` Lean files checked, down
-    from `24` — reflects only the two removed files; Phase 3 added
-    theorems to an existing file, not new files)
+  - Lean build: pass, 8340 jobs; **zero `sorry`s remain in
+    `proofs/LeanFormalization`** (unaffected — this run's changes are CI
+    workflow YAML, a helper script, and documentation, not Lean content)
+  - Vacuous/misleading-theorem lint: pass (`22` Lean files checked)
   - Traceability validation: pass (`10` modules, `84` theorem symbols, `34`
-    runtime test refs) — the theorem-symbol count reflects Phase 3's `+3`
-    (`binomial_mean`, `binomial_markov`, `probabilistic_hierarchical_bound`
-    added to row 1); removing the two orphaned files doesn't change this
-    count, since neither was ever referenced by this matrix
-  - Refinement drift check (`scripts/check_refinement.py`): pass (unaffected
-    by either piece of work — none of the touched files were ever part of
-    its manifest)
+    runtime test refs) — all unaffected by this run's changes
+  - Refinement drift check (`scripts/check_refinement.py`): pass (unaffected)
   - Formal validation report consistency: pass after regeneration
-  - Markdown link check: pass (167 files)
+  - Markdown link check: pass, but the count changed for a reason worth
+    recording: **`scripts/ci/check_markdown_links.py` had a real
+    non-determinism bug**, fixed in this run — its `IGNORE_DIRS` list didn't
+    exclude `.claude` or `.lake`, both local, untracked, non-project
+    directories (`.claude/worktrees/` can contain full duplicate repo
+    checkouts from worktree-isolated agent runs; `proofs/.lake/packages`
+    contains Mathlib's own vendored markdown docs). Depending on local
+    session/build state, this made the "files checked" count swing wildly
+    (423 was observed mid-session, once `.claude/worktrees` and a populated
+    `.lake` were both present) — this session's earlier, seemingly-stable
+    "167 files" readings were themselves already mildly inflated by a
+    partially-populated `.lake`. With both directories now excluded
+    (matching the existing `node_modules`/`.git`/`.github` exclusions for
+    the same "vendored or tool-owned, not project content" reason), the
+    check is deterministic and reflects only this repository's own tracked
+    documentation: **129 files**.

--- a/results/proofs/formal_validation_report.json
+++ b/results/proofs/formal_validation_report.json
@@ -8,7 +8,7 @@
       "surrogate_verified_with_gaussian_axiom": 1
     }
   },
-  "input_merkle_root": "9b5ddf4b6e9b19aa8cc5df2523823ffd2ef16eef21c65f03f2173ef311122a61",
+  "input_merkle_root": "68c085bd673586be9b6a82ed27426557e579b8848ba25573ddf8a1c9b71eb565",
   "inputs": [
     {
       "path": "capabilities.json",
@@ -20,7 +20,7 @@
     },
     {
       "path": "proofs/FORMAL_TRACEABILITY_MATRIX.md",
-      "sha256": "3e8ddea6ba04d53e60f584ff35d832054ac543e30ec107d1f46a98cce589fb06"
+      "sha256": "7b00b1bcfb115bd186f4437c4058307aec345440c402e11e61608c5922023139"
     },
     {
       "path": "proofs/LeanFormalization.lean",

--- a/scripts/apply_branch_protection.sh
+++ b/scripts/apply_branch_protection.sh
@@ -10,6 +10,13 @@ BRANCH="${BRANCH:-main}"
 #   export GITHUB_TOKEN=ghp_xxx
 #   bash scripts/apply_branch_protection.sh
 
+# NOTE: "Bridge Compression Benchmark / bridge-regression-compare" below is
+# known-stale as of 2026-08-04 -- no workflow with that name or job id
+# currently exists under .github/workflows/. Left in place pending
+# investigation into whether it should be restored or removed (see the
+# repo's task tracker / recent PR history); the other entries in this list
+# have been verified against real, current workflow/job names.
+
 PAYLOAD=$(cat <<'JSON'
 {
   "required_status_checks": {
@@ -19,15 +26,15 @@ PAYLOAD=$(cat <<'JSON'
       "Go Test / go-test",
       "Integrity Guard - Linter / lint",
       "Mainnet Readiness Gate / readiness-gate",
-      "Mainnet Chaos Gate / chaos-matrix",
+      "Mainnet Chaos Gate / chaos-gate",
       "Performance Gate / performance-gate",
       "Monitoring Smoke Gate / monitoring-smoke",
       "Release Performance Evidence / release-performance-evidence",
       "Bridge Compression Benchmark / bridge-regression-compare",
       "FedAvg Benchmark Compare / fedavg-benchmark-compare",
-      "Proof-Driven Design Verification / proof-audit",
+      "Proof-Driven Design Verification / verify-links",
       "Proof-Driven Design Verification / verify-lean-formalization",
-      "Capability Sync / sync-check"
+      "Capability Sync Check / validate-sync"
     ]
   },
   "enforce_admins": true,

--- a/scripts/apply_branch_protection.sh
+++ b/scripts/apply_branch_protection.sh
@@ -14,14 +14,9 @@ BRANCH="${BRANCH:-main}"
 # from the contexts below. The entire bridge feature (including the
 # bridge-compression-benchmark.yml workflow that produced this check) was
 # deleted in d7deb9682 ("Remove bridge surfaces and refresh validation
-# artifacts"), so no job by this name can ever report back to GitHub.
-
-# NOTE: "Bridge Compression Benchmark / bridge-regression-compare" below is
-# known-stale as of 2026-08-04 -- no workflow with that name or job id
-# currently exists under .github/workflows/. Left in place pending
-# investigation into whether it should be restored or removed (see the
-# repo's task tracker / recent PR history); the other entries in this list
-# have been verified against real, current workflow/job names.
+# artifacts"), so no job by this name can ever report back to GitHub. The
+# other entries in this list have all been verified against real, current
+# workflow/job names as of 2026-08-04.
 
 PAYLOAD=$(cat <<'JSON'
 {

--- a/scripts/ci/check_markdown_links.py
+++ b/scripts/ci/check_markdown_links.py
@@ -21,6 +21,8 @@ IMAGE_RE = re.compile(r"!\[[^\]]*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
 IGNORE_DIRS = {
     ".git",
     ".github",
+    ".claude",
+    ".lake",
     "node_modules",
     "test-results",
     "results",


### PR DESCRIPTION
## Summary

First Phase 4 (Governance/Audit) deliverable. Confirmed via `gh api repos/.../branches/main/protection` that the **live required status checks do not include `verify-lean-formalization` or `verify-lean-formalizations`** — the only Lean-aware required check, `full-validation-fast`, only ran `validate_formal_traceability.sh` (a symbol-name cross-reference check) via `make validate-formal-tooling-tests`, which itself only runs meta-tests of the validation *tooling*, never `lake build` or the vacuous-theorem lint. That combination lives in a separate `verify-formal-proofs` Makefile target that nothing required ever calls.

**Concretely: a PR could introduce a new `sorry`, a new vacuous theorem, or a Lean file that doesn't even compile, and merge to `main` cleanly.** This closes that gap.

- **`.github/workflows/full-validation-pr-gate.yml`**: adds the same Lean toolchain setup, Mathlib cache, `lake build LeanFormalization Specification Refinement`, and `lint_formal_proof_claims.py` steps `verify-lean-formalization` already runs, directly into the required `full-validation-fast` job (steps copied from that already-working job; the disk-cleanup step's `$AGENT_TOOLSDIRECTORY` removal is deliberately dropped since, unlike that job, this one already sets up Go/Python via actions and builds Go code later in the same job).
- **`docs/SUPPLY_CHAIN_SECURITY.md`**: corrects two places that (incorrectly) documented `verify-formal-proofs.yml` itself as "enforced as a separate, required CI gate" — it wasn't; now describes the real mechanism.
- **`README.md`**: corrects a stale "11 claims" count (actually 15) and clarifies which Lean CI jobs are required vs. informational-only.
- **`scripts/apply_branch_protection.sh`**: fixes three stale required-context entries found while investigating (none ever corresponded to real job names, confirmed via `git log -S` searches): `"proof-audit"` → `"verify-links"`, `"chaos-matrix"` → `"chaos-gate"`, `"Capability Sync / sync-check"` → `"Capability Sync Check / validate-sync"`. One more, `"Bridge Compression Benchmark"`, remains unresolved and is flagged separately (not fixed here). **This script is admin-only and was NOT run** — applying live branch-protection settings needs your explicit sign-off, separate from this PR.
- **`scripts/ci/check_markdown_links.py`**: fixes a real non-determinism bug found along the way — `IGNORE_DIRS` didn't exclude `.claude` (can contain full duplicate repo checkouts under `.claude/worktrees/` from worktree-isolated agent runs) or `.lake` (contains Mathlib's own vendored markdown docs). This made "files checked" swing with local session/build state (423 was observed mid-session); this session's earlier "167 files" readings were themselves already mildly inflated. Deterministic count with both excluded: **129**.

Adds a "CI Enforcement (Phase 4)" section to `proofs/FORMAL_TRACEABILITY_MATRIX.md` documenting all of the above.

## What this PR does NOT do

Does not touch live branch-protection settings. If you'd like `verify-lean-formalization`/`verify-lean-formalizations` added as required checks too (the architecturally cleaner fix — avoids the duplication this PR introduces between `full-validation-fast` and the existing Lean workflows), or want to run the corrected `apply_branch_protection.sh`, that's a separate decision for you to make.

## Test plan

- [x] `cd proofs && lake build LeanFormalization Specification Refinement` — 8340 jobs, pass, zero `sorry`s
- [x] `python3 scripts/ci/lint_formal_proof_claims.py --repo-root .` — pass
- [x] `bash scripts/ci/validate_formal_traceability.sh` — pass
- [x] `python3 scripts/ci/generate_formal_validation_report.py --repo-root . --check` — pass
- [x] `python3 scripts/ci/check_markdown_links.py` — pass, now deterministic (129 files)
- [x] `python3 scripts/check_refinement.py --lean proofs/Specification/System.lean --go internal/ --json` — pass
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/full-validation-pr-gate.yml'))"` — valid YAML
- [x] New workflow steps copied verbatim (action pins, command structure) from the already-working `verify-lean-formalization` job in `verify-proofs.yml`
- [ ] Actual CI run on this PR will be the first real test of the new `full-validation-fast` steps in a clean GitHub-hosted runner environment — worth watching closely

🤖 Generated with [Claude Code](https://claude.com/claude-code)