### PR TITLE
refactor(ci): dedupe Lean build+lint into one composite action

### DIFF
--- a/.github/actions/lean-build-and-lint/action.yml
+++ b/.github/actions/lean-build-and-lint/action.yml
@@ -1,0 +1,85 @@
+name: 'Build and lint Lean formal proofs'
+description: >
+  Installs elan, restores/saves the Lean/Lake build cache, builds the
+  LeanFormalization/Specification/Refinement lean_lib targets, and runs the
+  vacuous/misleading-theorem lint (scripts/ci/lint_formal_proof_claims.py).
+  Shared by every workflow that runs the real Lean verification gate
+  (full-validation-pr-gate.yml, verify-proofs.yml, verify-formal-proofs.yml)
+  so this logic lives in one place instead of three near-identical copies
+  that had to be kept in sync by hand.
+inputs:
+  remove-tools-dir:
+    description: >
+      Also remove $AGENT_TOOLSDIRECTORY during disk cleanup. Leave at the
+      default in jobs that already ran actions/setup-go or
+      actions/setup-python earlier in the same job and do more with Go or
+      Python afterward -- clearing the tool cache there risks breaking those
+      later steps.
+    required: false
+    default: 'false'
+runs:
+  using: 'composite'
+  steps:
+    - name: Free up disk space (critical for Mathlib)
+      shell: bash
+      run: |
+        df -h
+        echo "Cleaning up runner..."
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+        sudo rm -rf /usr/lib/jvm /usr/local/.ghcup /usr/share/swift /usr/local/share/powershell
+        sudo docker image prune -a -f || true
+        sudo docker builder prune -a -f || true
+        if [ "${{ inputs.remove-tools-dir }}" = "true" ]; then
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
+        fi
+        df -h
+
+    - name: Restore Lean/Lake cache
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      with:
+        path: |
+          proofs/.lake/packages
+          proofs/.lake/build
+        key: lean-lake-${{ runner.os }}-${{ hashFiles('proofs/lean-toolchain', 'proofs/lakefile.lean', 'proofs/lake-manifest.json') }}
+        restore-keys: |
+          lean-lake-${{ runner.os }}-
+
+    - name: Install elan
+      shell: bash
+      run: |
+        curl -fsSL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y
+        echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+    - name: Fetch prebuilt Mathlib cache
+      shell: bash
+      working-directory: proofs
+      run: |
+        lake update
+        lake exe cache get
+
+    - name: Build Lean formal theorem suite
+      shell: bash
+      working-directory: proofs
+      run: |
+        lake build LeanFormalization
+        lake build Specification
+        lake build Refinement
+        echo "All formal theorems compiled successfully."
+
+    - name: Lint formal proof claims (vacuous/misleading theorem scan)
+      shell: bash
+      run: python3 scripts/ci/lint_formal_proof_claims.py --repo-root .
+
+    - name: Cleanup transient Mathlib cache
+      if: always()
+      shell: bash
+      run: rm -rf "$MATHLIB_CACHE_DIR" || true
+
+    - name: Save Lean/Lake cache
+      if: always()
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      with:
+        path: |
+          proofs/.lake/packages
+          proofs/.lake/build
+        key: lean-lake-${{ runner.os }}-${{ hashFiles('proofs/lean-toolchain', 'proofs/lakefile.lean', 'proofs/lake-manifest.json') }}

--- a/.github/workflows/full-validation-pr-gate.yml
+++ b/.github/workflows/full-validation-pr-gate.yml
@@ -38,71 +38,17 @@ jobs:
       # in the tree) but never actually compiled the Lean proofs or ran the
       # vacuous/misleading-theorem lint -- a PR could introduce a new sorry,
       # a new vacuous theorem, or a Lean file that doesn't even compile, and
-      # merge to main cleanly. The "Build Lean formal theorem suite" and
-      # "Lint formal proof claims" steps below close that gap by running
-      # the same real checks verify-lean-formalization already runs,
-      # directly in the required job instead of a non-required sibling
-      # (the cache/toolchain steps around them are plumbing copied from
-      # that job to make the build/lint steps possible here).
-      - name: Free up disk space (critical for Mathlib)
-        # Deliberately does NOT remove $AGENT_TOOLSDIRECTORY, unlike the
-        # otherwise-identical step in verify-proofs.yml: this job (unlike
-        # that one) already ran actions/setup-go and actions/setup-python
-        # above and also builds/tests Go code later in the same job, so
-        # clearing the tool cache here risks breaking those later steps.
-        run: |
-          df -h
-          echo "Cleaning up runner..."
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/lib/jvm /usr/local/.ghcup /usr/share/swift /usr/local/share/powershell
-          sudo docker image prune -a -f || true
-          sudo docker builder prune -a -f || true
-          df -h
-
-      - name: Restore Lean/Lake cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: |
-            proofs/.lake/packages
-            proofs/.lake/build
-          key: lean-lake-${{ runner.os }}-${{ hashFiles('proofs/lean-toolchain', 'proofs/lakefile.lean', 'proofs/lake-manifest.json') }}
-          restore-keys: |
-            lean-lake-${{ runner.os }}-
-
-      - name: Install elan
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-
-      - name: Fetch prebuilt Mathlib cache
-        working-directory: proofs
-        run: |
-          lake update
-          lake exe cache get
-
-      - name: Build Lean formal theorem suite
-        working-directory: proofs
-        run: |
-          lake build LeanFormalization
-          lake build Specification
-          lake build Refinement
-          echo "All formal theorems compiled successfully."
-
-      - name: Lint formal proof claims (vacuous/misleading theorem scan)
-        run: python3 scripts/ci/lint_formal_proof_claims.py --repo-root .
-
-      - name: Cleanup transient Mathlib cache
-        if: always()
-        run: rm -rf "$MATHLIB_CACHE_DIR" || true
-
-      - name: Save Lean/Lake cache
-        if: always()
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: |
-            proofs/.lake/packages
-            proofs/.lake/build
-          key: lean-lake-${{ runner.os }}-${{ hashFiles('proofs/lean-toolchain', 'proofs/lakefile.lean', 'proofs/lake-manifest.json') }}
+      # merge to main cleanly. The composite action below closes that gap by
+      # running the same real checks verify-lean-formalization already runs,
+      # directly in the required job instead of a non-required sibling.
+      #
+      # remove-tools-dir is deliberately left at its 'false' default here,
+      # unlike the other two callers of this action: this job already ran
+      # actions/setup-go and actions/setup-python above and also
+      # builds/tests Go code later in the same job, so clearing the tool
+      # cache here risks breaking those later steps.
+      - name: Build and lint Lean formal proofs
+        uses: ./.github/actions/lean-build-and-lint
 
       - name: Validate formal report consistency and bundle integrity
         run: |

--- a/.github/workflows/verify-formal-proofs.yml
+++ b/.github/workflows/verify-formal-proofs.yml
@@ -43,45 +43,9 @@ jobs:
       MATHLIB_CACHE_DIR: ${{ github.workspace }}/proofs/.lake/mathlib-cache
     
     steps:
-      - name: Free disk space (critical for Mathlib)
-        run: |
-          df -h
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/lib/jvm /usr/local/.ghcup /usr/share/swift /usr/local/share/powershell
-          sudo docker image prune -a -f || true
-          sudo docker builder prune -a -f || true
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
-          df -h
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
-
-      - name: Install Lean 4 (Elan)
-        run: |
-          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-
-      - name: Verify Lean version
-        run: |
-          lean --version
-          lake --version
-
-      - name: Restore Lean/Lake cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: |
-            proofs/.lake/packages
-            proofs/.lake/build
-          key: lean-lake-${{ runner.os }}-${{ hashFiles('proofs/lean-toolchain', 'proofs/lakefile.lean', 'proofs/lake-manifest.json') }}
-          restore-keys: |
-            lean-lake-${{ runner.os }}-
-
-      - name: Update Lake dependencies and fetch Mathlib cache
-        working-directory: ./proofs
-        run: |
-          lake update
-          lake exe cache get
 
       - name: Scan for unsafe placeholders
         working-directory: ./proofs
@@ -98,27 +62,29 @@ jobs:
               FOUND_SORRY="$FOUND_SORRY $file"
             fi
           done
-          
+
           if [ -n "$FOUND_UNSAFE" ]; then
             echo "❌ Unsafe formal proof placeholders found (axiom/admit):$FOUND_UNSAFE"
             exit 1
           fi
-          
+
           if [ -n "$FOUND_SORRY" ]; then
             echo "⚠ Phase 3e: $(($(grep -RIn '\bsorry\b' LeanFormalization Specification Refinement *.lean 2>/dev/null | wc -l))) honest in-progress proofs (sorry) detected"
           fi
           echo "✓ Placeholder scan passed (unsafe axiom/admit rejected, honest sorry allowed for Phase 3e)"
 
-      - name: Build Lean formalizations
-        working-directory: ./proofs
-        run: |
-          lake build LeanFormalization
-          lake build Specification
-          lake build Refinement
-          echo "✅ All formal theorems compiled successfully."
-
-      - name: Lint formal proof claims (vacuous/misleading theorem scan)
-        run: python3 scripts/ci/lint_formal_proof_claims.py --repo-root .
+      # See .github/actions/lean-build-and-lint/action.yml for what this
+      # does. remove-tools-dir: 'true' matches this job's prior behavior --
+      # this job never runs actions/setup-go or actions/setup-python, so
+      # clearing $AGENT_TOOLSDIRECTORY here is safe. The standalone
+      # "Verify Lean version" step (lean --version / lake --version) that
+      # used to sit between elan install and cache restore was dropped: it
+      # was diagnostic output only, asserted nothing, and duplicated across
+      # all three callers of this action.
+      - name: Build and lint Lean formal proofs
+        uses: ./.github/actions/lean-build-and-lint
+        with:
+          remove-tools-dir: 'true'
 
       - name: Check spec-to-implementation refinement alignment
         run: |
@@ -153,20 +119,6 @@ jobs:
       - name: Run formal validation tooling tests
         run: |
           make validate-formal-tooling-tests
-
-      - name: Save Lean/Lake cache
-        if: always()
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: |
-            proofs/.lake/packages
-            proofs/.lake/build
-          key: lean-lake-${{ runner.os }}-${{ hashFiles('proofs/lean-toolchain', 'proofs/lakefile.lean', 'proofs/lake-manifest.json') }}
-
-      - name: Cleanup transient Mathlib cache
-        if: always()
-        run: |
-          rm -rf "$MATHLIB_CACHE_DIR" || true
 
       - name: Generate proof verification report
         if: always()

--- a/.github/workflows/verify-proofs.yml
+++ b/.github/workflows/verify-proofs.yml
@@ -45,40 +45,8 @@ jobs:
     env:
       MATHLIB_CACHE_DIR: ${{ github.workspace }}/proofs/.lake/mathlib-cache
     steps:
-      - name: Free up disk space (critical for Mathlib)
-        run: |
-          df -h
-          echo "Cleaning up runner..."
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/lib/jvm /usr/local/.ghcup /usr/share/swift /usr/local/share/powershell
-          sudo docker image prune -a -f || true
-          sudo docker builder prune -a -f || true
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
-          df -h
-
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-
-      - name: Restore Lean/Lake cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: |
-            proofs/.lake/packages
-            proofs/.lake/build
-          key: lean-lake-${{ runner.os }}-${{ hashFiles('proofs/lean-toolchain', 'proofs/lakefile.lean', 'proofs/lake-manifest.json') }}
-          restore-keys: |
-            lean-lake-${{ runner.os }}-
-
-      - name: Install elan
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-
-      - name: Fetch prebuilt Mathlib cache
-        working-directory: proofs
-        run: |
-          lake update
-          lake exe cache get
 
       - name: Ensure no unsafe placeholders and track `sorry`
         working-directory: proofs
@@ -97,16 +65,14 @@ jobs:
           chmod +x ../scripts/ci/validate_formal_traceability.sh
             ../scripts/ci/validate_formal_traceability.sh
 
-      - name: Build Lean formal theorem suite
-        working-directory: proofs
-        run: |
-          lake build LeanFormalization
-          lake build Specification
-          lake build Refinement
-          echo "✅ All formal theorems compiled successfully."
-
-      - name: Lint formal proof claims (vacuous/misleading theorem scan)
-        run: python3 scripts/ci/lint_formal_proof_claims.py --repo-root .
+      # See .github/actions/lean-build-and-lint/action.yml for what this
+      # does. remove-tools-dir: 'true' matches this job's prior behavior --
+      # unlike full-validation-fast, this job never runs actions/setup-go or
+      # actions/setup-python, so clearing $AGENT_TOOLSDIRECTORY here is safe.
+      - name: Build and lint Lean formal proofs
+        uses: ./.github/actions/lean-build-and-lint
+        with:
+          remove-tools-dir: 'true'
 
       - name: Check spec-to-implementation refinement alignment
         run: |
@@ -137,20 +103,6 @@ jobs:
       - name: Check theorem/runtime consistency
         run: |
           python3 scripts/ci/check_theorem_runtime_consistency.py
-
-      - name: Cleanup transient Mathlib cache
-        if: always()
-        run: |
-          rm -rf "$MATHLIB_CACHE_DIR" || true
-
-      - name: Save Lean/Lake cache
-        if: always()
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: |
-            proofs/.lake/packages
-            proofs/.lake/build
-          key: lean-lake-${{ runner.os }}-${{ hashFiles('proofs/lean-toolchain', 'proofs/lakefile.lean', 'proofs/lake-manifest.json') }}
 
       - name: Generate formal proof artifacts
         working-directory: proofs

--- a/scripts/ci/check_workflow_action_pins.py
+++ b/scripts/ci/check_workflow_action_pins.py
@@ -31,11 +31,19 @@ def action_repo_slug(action: str) -> str | None:
 
 
 def validate_uses(value: str) -> str | None:
+    # Local composite/reusable actions (`./path/to/action`) are resolved
+    # from the same commit as the workflow itself, so there is no separate
+    # ref to pin -- and no `@` suffix at all is the normal, expected form
+    # (unlike third-party `owner/repo@ref` actions). Docker actions can
+    # likewise reference a tag with no `@digest`. Both must be exempted
+    # from the "missing @ref" check itself, not just from the SHA-format
+    # check that runs after it.
+    action = value.split("@", 1)[0]
+    if is_local_action(action) or is_docker_action(value):
+        return None
     if "@" not in value:
         return f"missing @ref: {value}"
-    action, ref = value.rsplit("@", 1)
-    if is_local_action(action) or is_docker_action(action):
-        return None
+    _, ref = value.rsplit("@", 1)
     if not SHA_RE.fullmatch(ref):
         return f"not pinned to 40-char SHA: {value}"
     return None
@@ -83,10 +91,11 @@ def main() -> int:
                 violations.append(f"{workflow}:{i}: {issue}")
                 continue
 
-            action, ref = value.rsplit("@", 1)
-            if is_local_action(action) or is_docker_action(action):
+            action = value.split("@", 1)[0]
+            if is_local_action(action) or is_docker_action(value):
                 continue
 
+            _, ref = value.rsplit("@", 1)
             repo_slug = action_repo_slug(action)
             if repo_slug is None:
                 violations.append(f"{workflow}:{i}: unable to parse action repo: {value}")


### PR DESCRIPTION
## Summary
- `full-validation-fast` (required), `verify-lean-formalization`, and `verify-lean-formalizations` each ran their own near-identical copy of "install elan, restore/save the Lake cache, fetch Mathlib, `lake build LeanFormalization Specification Refinement`, lint vacuous-theorem claims" -- three copies that had already drifted slightly and had to be hand-kept in sync.
- Extracted the shared logic into `.github/actions/lean-build-and-lint`, a composite action parameterized by `remove-tools-dir` for the one real behavioral difference between callers (`full-validation-fast` already ran `actions/setup-go`/`setup-python` earlier in the same job, so it must not clear `$AGENT_TOOLSDIRECTORY`; the other two callers may).
- Fixed a latent bug in `scripts/ci/check_workflow_action_pins.py` this surfaced: it flagged the new local `uses: ./.github/actions/...` reference as `"missing @ref"` even though `is_local_action()` exists specifically to exempt local actions from ref-pinning -- the missing-`@` check ran before that exemption was applied. Local composite actions have no `@ref` at all by design (nothing separate to pin, they resolve from the same commit as the workflow).
- Dropped the standalone "Verify Lean version" step from `verify-formal-proofs.yml` (`lean --version` / `lake --version`): pure diagnostic output that asserted nothing, and would have been a fourth duplicated copy to maintain.
- No change in what gets verified: same `lake build` targets, same lint script, same required/non-required status-check set. This is a refactor, not a policy change.

## Test plan
- [x] `python3 -c "yaml.safe_load(...)"` on all 4 touched YAML files
- [x] `python3 scripts/ci/check_workflow_action_pins.py` passes (confirms the local-action fix works and nothing else regressed)
- [x] `black --check --config sdk/python/pyproject.toml scripts/ci/check_workflow_action_pins.py` passes
- [x] `python3 scripts/ci/lint_formal_proof_claims.py --repo-root .` and `bash scripts/ci/validate_formal_traceability.sh` pass locally (unaffected by this change, sanity-checked anyway)
- [ ] CI: `full-validation-fast`, `verify-lean-formalization`, `verify-lean-formalizations`, and `pin-check` all need to go green on this PR before merge -- that's the real end-to-end proof the composite action behaves identically to the three inlined copies it replaces