### PR TITLE
feat(formal-verification): machine-checked audit log for claim transitions

### DIFF
--- a/.github/workflows/full-validation-pr-gate.yml
+++ b/.github/workflows/full-validation-pr-gate.yml
@@ -19,6 +19,18 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
+      # The checkout above is shallow (default fetch-depth), so
+      # origin/main doesn't exist locally yet -- fetch just its tip so the
+      # claim-transition check below has something to diff against.
+      - name: Fetch main for claim-transition diff
+        run: git fetch --no-tags --depth=1 origin main
+
+      # Fails the PR if it silently changes a FORMAL_TRACEABILITY_MATRIX.md
+      # Status value without a matching new proofs/CLAIM_TRANSITIONS.md
+      # entry explaining the transition. See that file for the process.
+      - name: Check formal claim Status transitions are logged
+        run: python3 scripts/ci/check_claim_transitions.py
+
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:

--- a/proofs/CLAIM_TRANSITIONS.md
+++ b/proofs/CLAIM_TRANSITIONS.md
@@ -1,0 +1,65 @@
+# Claim Transition Log
+
+Append-only record of every change to a `Status` column value in
+[`FORMAL_TRACEABILITY_MATRIX.md`](FORMAL_TRACEABILITY_MATRIX.md) (both its
+main table and its Workstream 4 table). This is the audit/sign-off
+mechanism for Phase 4 of the Formal Verification Completion effort: a
+claim's Status can move for good reasons (a `sorry` closed for real, a
+vacuous theorem replaced, a gap honestly demoted and documented) or bad
+ones (quietly inflating or weakening a claim without explanation), and
+this log is what lets a reviewer tell the two apart without re-deriving
+the whole history from `git blame`.
+
+## How this is enforced
+
+`scripts/ci/check_claim_transitions.py`, run as part of the
+`full-validation-fast` required status check, diffs every row's `Status`
+column between `origin/main` and the PR's working tree. Any row whose
+`Status` changed must have a matching **new** heading added to this file
+in the same PR -- "new" specifically, so a generic entry can't be
+pre-seeded once and silently reused to wave through unrelated later
+changes. The check fails the PR otherwise.
+
+## Entry format
+
+```
+## <date> -- Row <id> (<claim short name>): <old status> -> <new status>
+
+<1-3 sentences: what changed and why. Can point back to the matrix row's
+own Notes column for the full technical reasoning -- this log exists to
+record THAT a transition happened and its headline direction, not to
+duplicate the matrix's detailed rationale.>
+
+- **PR:** #<number>
+```
+
+`<id>` must exactly match that row's first-column value in the matrix
+(`1`-`15` for the main table, `Theorem7`/`Theorem8` for the Workstream 4
+table). The `<old status> -> <new status>` text does not need to be
+character-for-character identical to the matrix cells (the checker only
+requires the heading to exist and reference the right row id) but should
+accurately summarize the real transition.
+
+## Log
+
+### 2026-08-04 -- Row 2 (RDP composition): closed adaptive composition
+
+`surrogate_verified_with_gaussian_axiom; core composition closed for
+independent mechanisms (adaptive composition out of scope)` ->
+`surrogate_verified_with_gaussian_axiom; core composition closed for both
+independent and adaptive mechanisms`
+
+Closed the "adaptive composition ... out of scope" gap for real with
+`RDP_adaptive_composition`, using the corrected uniform-bound formulation
+(Mironov 2017, Prop. 1) after the originally-cited expectation-based chain
+rule turned out not to be a valid Rényi-divergence identity. See the
+matrix row's own Notes for the full derivation.
+
+- **PR:** #145
+
+---
+
+*Entries above this line are backfilled for historical context (this log
+did not exist yet when they landed) and were not machine-enforced at the
+time. Enforcement via `check_claim_transitions.py` begins with the PR
+that introduced this file.*

--- a/proofs/FORMAL_TRACEABILITY_MATRIX.md
+++ b/proofs/FORMAL_TRACEABILITY_MATRIX.md
@@ -125,6 +125,20 @@ stale entries unrelated to formal verification (`chaos-matrix` →
 and fixed in the same pass, and one (`Bridge Compression Benchmark`) remains
 open, flagged separately.
 
+### Claim-transition audit log
+
+As of 2026-08-07, `full-validation-fast` also runs
+`scripts/ci/check_claim_transitions.py`, which fails a PR that changes any
+row's `Status` cell in this matrix (main table or the Workstream 4 table)
+without a matching new entry in
+[`CLAIM_TRANSITIONS.md`](CLAIM_TRANSITIONS.md). This is the machine-checked
+half of the Phase 4 audit/sign-off process this matrix's own history section
+above had flagged as unbuilt: it doesn't judge whether a transition is a
+real closure or a demotion versus an inflation, but it does make it
+impossible to change a claim's stated strength silently — every Status
+change now requires a human-written, PR-linked explanation, checked into the
+same tree the claim itself lives in.
+
 ## Latest Validation Run
 
 - Date (UTC): 2026-08-04

--- a/scripts/ci/check_claim_transitions.py
+++ b/scripts/ci/check_claim_transitions.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Fail a PR that silently changes a formal-verification claim's Status.
+
+Every row of proofs/FORMAL_TRACEABILITY_MATRIX.md's main table and its
+Workstream 4 table carries a Status column asserting how far that claim's
+Lean proof goes (fully_formalized, surrogate_verified_with_gaussian_axiom,
+model_verified, and so on). Changing that value -- closing a sorry,
+demoting a claim, narrowing its scope -- is exactly the kind of transition
+this repo's formal-verification effort exists to keep honest: closed for
+real, or explicitly demoted and explained, never silently inflated or
+silently downgraded without a record.
+
+This script diffs the matrix's Status columns between a base ref (default
+origin/main) and the working tree. For every row whose Status changed, it
+requires a matching, newly-added heading in proofs/CLAIM_TRANSITIONS.md --
+"newly added" so a generic entry can't be pre-seeded once and reused to
+wave through unrelated future changes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from pathlib import Path
+
+MATRIX_PATH = "proofs/FORMAL_TRACEABILITY_MATRIX.md"
+TRANSITIONS_PATH = Path("proofs/CLAIM_TRANSITIONS.md")
+
+ROW_RE = re.compile(r"^\|(.+)\|\s*$")
+SEP_RE = re.compile(r"^\|[\s:|-]+\|\s*$")
+TRANSITION_HEADING_RE = re.compile(
+    r"^##\s+.*--\s*Row\s+(\S+).*:\s*(.+?)\s*->\s*(.+?)\s*$", re.MULTILINE
+)
+
+
+def parse_tables(text: str) -> dict[str, str]:
+    """Return {"<table_idx>:<row_key>": status_value} for every data row of
+    every pipe-table in the matrix that has a 'Status' column. row_key is
+    that row's first-column value (the claim/theorem id), which the matrix
+    itself already treats as a stable identifier."""
+    statuses: dict[str, str] = {}
+    lines = text.splitlines()
+    table_idx = -1
+    i = 0
+    while i < len(lines):
+        header_match = ROW_RE.match(lines[i])
+        if header_match and i + 1 < len(lines) and SEP_RE.match(lines[i + 1]):
+            table_idx += 1
+            headers = [c.strip() for c in header_match.group(1).split("|")]
+            j = i + 2
+            if "Status" not in headers:
+                while j < len(lines) and ROW_RE.match(lines[j]):
+                    j += 1
+                i = j
+                continue
+            status_col = headers.index("Status")
+            while j < len(lines) and ROW_RE.match(lines[j]):
+                cells = [c.strip() for c in ROW_RE.match(lines[j]).group(1).split("|")]
+                if len(cells) > status_col:
+                    statuses[f"{table_idx}:{cells[0]}"] = cells[status_col]
+                j += 1
+            i = j
+            continue
+        i += 1
+    return statuses
+
+
+def git_show(ref: str, path: str) -> str | None:
+    proc = subprocess.run(
+        ["git", "show", f"{ref}:{path}"],
+        capture_output=True,
+        encoding="utf-8",
+        check=False,
+    )
+    return proc.stdout if proc.returncode == 0 else None
+
+
+def transition_log_row_ids(text: str) -> set[str]:
+    return {m.group(1) for m in TRANSITION_HEADING_RE.finditer(text)}
+
+
+def new_transition_log_entries(base_ref: str) -> set[str]:
+    base_text = git_show(base_ref, str(TRANSITIONS_PATH)) or ""
+    head_text = TRANSITIONS_PATH.read_text(encoding="utf-8") if TRANSITIONS_PATH.exists() else ""
+    return transition_log_row_ids(head_text) - transition_log_row_ids(base_text)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-ref",
+        default="origin/main",
+        help="Git ref to diff the matrix against (default: origin/main).",
+    )
+    args = parser.parse_args()
+
+    base_matrix = git_show(args.base_ref, MATRIX_PATH)
+    if base_matrix is None:
+        print(
+            f"No base matrix found at {args.base_ref}:{MATRIX_PATH} -- "
+            "skipping (nothing to diff against)."
+        )
+        return 0
+
+    head_matrix = Path(MATRIX_PATH).read_text(encoding="utf-8")
+
+    base_statuses = parse_tables(base_matrix)
+    head_statuses = parse_tables(head_matrix)
+
+    changed = {
+        key: (base_statuses[key], head_statuses[key])
+        for key in head_statuses
+        if key in base_statuses and base_statuses[key] != head_statuses[key]
+    }
+
+    if not changed:
+        print("No claim Status transitions in this diff.")
+        return 0
+
+    logged_row_ids = new_transition_log_entries(args.base_ref)
+
+    missing = [
+        (key.split(":", 1)[1], old, new)
+        for key, (old, new) in changed.items()
+        if key.split(":", 1)[1] not in logged_row_ids
+    ]
+
+    if missing:
+        print(
+            "Claim Status transition(s) found with no matching new entry in " f"{TRANSITIONS_PATH}:"
+        )
+        for row_id, old, new in missing:
+            print(f"  - Row {row_id}: {old!r} -> {new!r}")
+        print(
+            "\nAdd a heading of the form "
+            "'## <date> -- Row <id> (<claim short name>): <old status> "
+            f"-> <new status>' to {TRANSITIONS_PATH}, with a short "
+            "rationale underneath, before merging."
+        )
+        return 1
+
+    print(
+        f"All {len(changed)} claim Status transition(s) have a matching "
+        f"new {TRANSITIONS_PATH} entry."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Phase 4 of the Formal Verification Completion effort has always relied on someone noticing when a `FORMAL_TRACEABILITY_MATRIX.md` row's `Status` value changes and judging whether that's a real closure, an honest demotion, or a silent inflation. Nothing enforced that a transition even gets explained -- this was explicitly flagged as unbuilt, only explored.
- Adds `scripts/ci/check_claim_transitions.py`: diffs every row's `Status` cell (main table + Workstream 4 table) against `origin/main`, and fails if any changed without a matching **new** heading in the new `proofs/CLAIM_TRANSITIONS.md` log added in the same PR. "New" specifically -- a generic entry can't be pre-seeded once and reused to wave through unrelated later changes.
- Seeded the log with one real backfilled entry: row 2's transition when Track C ([PR #145](https://github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/pull/145)) closed adaptive RDP composition, with before/after Status text pulled via `git show` against that actual commit, not reconstructed from memory.
- Documented the new gate in the matrix's own "CI Enforcement (Phase 4)" section.

## Heads up: this becomes an enforced gate immediately on merge
`full-validation-fast` is already a required status check, so wiring this checker into it (rather than a non-required sibling workflow) means every future PR that changes a matrix Status cell will need a `CLAIM_TRANSITIONS.md` entry starting the moment this merges -- no separate branch-protection change needed, since the job itself is already required. Flagging this explicitly since it's a real behavior change to what blocks merges to `main`, even though it doesn't touch branch-protection settings themselves.

## Test plan
- [x] Simulated a Status change locally (mutated a row, confirmed the checker fails with no log entry, added a matching entry, confirmed it passes)
- [x] `python3 scripts/ci/check_claim_transitions.py` against the real diff (no Status change in this PR) -- passes as a no-op
- [x] `lint_formal_proof_claims.py`, `validate_formal_traceability.sh`, `check_markdown_links.py` all still pass after the matrix doc edit
- [x] `black --check --config sdk/python/pyproject.toml` and the workflow-action-pin-check both pass
- [ ] CI: `full-validation-fast` needs to go green on this PR itself (exercises the new "Fetch main for claim-transition diff" + checker steps for real, including the shallow-clone fetch)