### PR TITLE
feat(formal-verification): RDP accountant trace schema + Go instrumentation

### DIFF
--- a/internal/rdp_accountant.go
+++ b/internal/rdp_accountant.go
@@ -18,9 +18,11 @@ package internal
 
 import (
 	"fmt"
+	"io"
 	"math"
 	"math/big"
 	"sync"
+	"sync/atomic"
 
 	"github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/internal/metrics"
 )
@@ -34,6 +36,13 @@ type RDPAccountant struct {
 	MaxBudget    *big.Rat // Target (ε, δ)-DP limit (e.g., 2.0)
 	TargetDelta  float64  // Fixed delta (e.g., 10⁻⁵)
 	ShardEpsilon map[string]*big.Rat
+
+	// TraceSink, when non-nil, receives one JSONL TraceEvent line per
+	// RecordStepRat/RecordShardStepRat/CheckBudget call -- see
+	// proofs/TraceValidator/RDPAccountant.lean. Nil by default: strictly
+	// opt-in, zero behavior change and zero overhead when untraced.
+	TraceSink io.Writer
+	traceSeq  atomic.Int64
 }
 
 // NewRDPAccountant initializes the accountant with research-backed defaults.
@@ -67,6 +76,14 @@ func (a *RDPAccountant) RecordStepRat(epsilon *big.Rat) {
 		return
 	}
 	a.TotalEpsilon.Add(a.TotalEpsilon, epsilon)
+	if a.TraceSink != nil {
+		a.writeTrace(TraceEvent{
+			Event:             "record_step",
+			Seq:               a.traceSeq.Add(1),
+			Epsilon:           epsilon.RatString(),
+			CumulativeEpsilon: a.TotalEpsilon.RatString(),
+		})
+	}
 }
 
 // RecordShardStep tracks epsilon usage in a shard-level sub-ledger while
@@ -90,6 +107,15 @@ func (a *RDPAccountant) RecordShardStepRat(shardID string, epsilon *big.Rat) {
 	}
 	a.ShardEpsilon[shardID].Add(a.ShardEpsilon[shardID], epsilon)
 	a.TotalEpsilon.Add(a.TotalEpsilon, epsilon)
+	if a.TraceSink != nil {
+		a.writeTrace(TraceEvent{
+			Event:             "record_shard_step",
+			Seq:               a.traceSeq.Add(1),
+			ShardID:           shardID,
+			Epsilon:           epsilon.RatString(),
+			CumulativeEpsilon: a.TotalEpsilon.RatString(),
+		})
+	}
 }
 
 // GetShardEpsilonRat returns the shard-level cumulative epsilon.
@@ -173,7 +199,19 @@ func (a *RDPAccountant) CheckBudget() error {
 	if currentFloat, ok := current.Float64(); ok {
 		metrics.ObserveFormalRDPComposition("accountant", currentFloat)
 	}
-	if current.Cmp(a.MaxBudget) > 0 {
+	exceeded := current.Cmp(a.MaxBudget) > 0
+	if a.TraceSink != nil {
+		ok := !exceeded
+		a.writeTrace(TraceEvent{
+			Event:             "check_budget",
+			Seq:               a.traceSeq.Add(1),
+			CumulativeEpsilon: a.TotalEpsilon.RatString(),
+			MaxBudget:         a.MaxBudget.RatString(),
+			ConversionTerm:    ratFromFloat64(conversion).RatString(),
+			BudgetOK:          &ok,
+		})
+	}
+	if exceeded {
 		return fmt.Errorf(
 			"privacy budget exhausted: current ε=%s exceeds limit ε=%s",
 			current.RatString(),

--- a/internal/rdp_trace.go
+++ b/internal/rdp_trace.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Sovereign-Mohawk Core Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import "encoding/json"
+
+// TraceEvent is one line of a JSONL execution trace of an RDPAccountant,
+// emitted when RDPAccountant.TraceSink is set. See
+// proofs/TraceValidator/RDPAccountant.lean for the Lean-side consumer that
+// replays these events through the already-proven composeRDP ledger model
+// (proofs/Refinement/RDPAccountant.lean) and checks the Go execution
+// matches it exactly.
+//
+// Rational quantities are stringified via (*big.Rat).RatString() rather
+// than converted to float64, so the Lean side can compare them exactly --
+// the same precision guarantee the four fixed test vectors in
+// FORMAL_TRACEABILITY_MATRIX.md row 13 already rely on, just extended to a
+// live, dynamic call sequence instead of a handful of pinned scenarios.
+//
+// ConversionTerm is a snapshot of Go's own log(1/delta)/(alpha-1) term
+// (computed via math.Log, not exact rational arithmetic) and is
+// informational only: Lean's Real.log is noncomputable, so the Lean
+// validator cannot independently re-derive this term and pin it exactly
+// the way it can the raw additive ledger. What it can and does check is
+// that BudgetOK is the correct conclusion from CumulativeEpsilon +
+// ConversionTerm vs MaxBudget -- i.e. that CheckBudget's decision was
+// actually computed from the same exact ledger value Lean's ledger replay
+// independently arrives at, not a stale or diverged one.
+type TraceEvent struct {
+	Event             string `json:"event"` // "record_step" | "record_shard_step" | "check_budget"
+	Seq               int64  `json:"seq"`
+	ShardID           string `json:"shard_id,omitempty"`
+	Epsilon           string `json:"epsilon,omitempty"`         // record_step / record_shard_step only
+	CumulativeEpsilon string `json:"cumulative_epsilon"`        // TotalEpsilon after this event, exact rational
+	MaxBudget         string `json:"max_budget,omitempty"`      // check_budget only
+	ConversionTerm    string `json:"conversion_term,omitempty"` // check_budget only; see doc comment above
+	BudgetOK          *bool  `json:"budget_ok,omitempty"`       // check_budget only
+}
+
+// writeTrace best-effort emits ev as one JSON line to a.TraceSink. Tracing
+// must never be able to break accountant behavior: a nil sink is a no-op,
+// and marshal/write failures are swallowed rather than propagated.
+func (a *RDPAccountant) writeTrace(ev TraceEvent) {
+	if a.TraceSink == nil {
+		return
+	}
+	line, err := json.Marshal(ev)
+	if err != nil {
+		return
+	}
+	line = append(line, '\n')
+	_, _ = a.TraceSink.Write(line)
+}

--- a/test/rdp_accountant_trace_test.go
+++ b/test/rdp_accountant_trace_test.go
@@ -1,0 +1,112 @@
+package test
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	internal "github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/internal"
+)
+
+// TestRDPAccountantTrace drives a realistic multi-shard, multi-round
+// RDPAccountant execution with tracing enabled and writes the resulting
+// JSONL trace to test-results/rdp-trace/trace.jsonl. That file is the input
+// to the Lean trace validator (proofs/TraceValidator/RDPAccountant.lean),
+// which replays every event through the already-proven composeRDP ledger
+// model (proofs/Refinement/RDPAccountant.lean) and checks the Go execution
+// matches it exactly -- extending the four fixed vectors in
+// FORMAL_TRACEABILITY_MATRIX.md row 13 to a live, dynamic call sequence.
+//
+// The scenario: three shards each take two RecordShardStepRat steps, with
+// a CheckBudget call after each shard's second step (all within budget),
+// then a final large RecordStepRat step that deliberately exceeds the
+// budget, followed by one last CheckBudget call that must report exceeded
+// -- so the trace exercises both budget outcomes, not just the passing case.
+func TestRDPAccountantTrace(t *testing.T) {
+	var buf bytes.Buffer
+	// MaxBudget=5.0 leaves headroom above CheckBudget's fixed conversion
+	// term (log(1/delta)/(alpha-1) ~= 1.279 at delta=1e-5, alpha=10 -- the
+	// accountant's default Alpha) plus this scenario's ~0.30 shard total,
+	// so the three mid-scenario checks land comfortably within budget
+	// (current ~= 1.58 < 5.0) while the final +10 push deliberately clears
+	// it (current ~= 11.58 > 5.0).
+	acc := internal.NewRDPAccountant(5.0, 1e-5)
+	acc.TraceSink = &buf
+
+	shardSteps := map[string][2]*big.Rat{
+		"shard-a": {big.NewRat(1, 20), big.NewRat(3, 50)},
+		"shard-b": {big.NewRat(1, 10), big.NewRat(1, 25)},
+		"shard-c": {big.NewRat(3, 100), big.NewRat(1, 50)},
+	}
+	// Deterministic order for a reproducible trace.
+	shardOrder := []string{"shard-a", "shard-b", "shard-c"}
+
+	for _, shard := range shardOrder {
+		steps := shardSteps[shard]
+		acc.RecordShardStepRat(shard, steps[0])
+		acc.RecordShardStepRat(shard, steps[1])
+		if err := acc.CheckBudget(); err != nil {
+			t.Fatalf("shard %s: expected budget within limit mid-scenario, got: %v", shard, err)
+		}
+	}
+
+	// Push the ledger over MaxBudget (5.0) on purpose.
+	acc.RecordStepRat(big.NewRat(10, 1))
+	if err := acc.CheckBudget(); err == nil {
+		t.Fatal("expected final CheckBudget to report budget exceeded, got nil error")
+	}
+
+	events := parseTraceLines(t, buf.Bytes())
+	if len(events) == 0 {
+		t.Fatal("expected at least one traced event, got none")
+	}
+	last := events[len(events)-1]
+	if last.Event != "check_budget" || last.BudgetOK == nil || *last.BudgetOK {
+		t.Fatalf("expected final traced event to be a failing check_budget, got %+v", last)
+	}
+
+	writeTraceArtifact(t, buf.Bytes())
+}
+
+func parseTraceLines(t *testing.T, data []byte) []internal.TraceEvent {
+	t.Helper()
+	var events []internal.TraceEvent
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var ev internal.TraceEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			t.Fatalf("failed to parse traced JSONL line %q: %v", line, err)
+		}
+		events = append(events, ev)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("failed scanning trace buffer: %v", err)
+	}
+	return events
+}
+
+// writeTraceArtifact writes the raw trace to
+// <repo-root>/test-results/rdp-trace/trace.jsonl. Go test binaries run with
+// their working directory set to the package's source directory (test/),
+// so ".." resolves to the repo root regardless of where `go test` itself
+// was invoked from -- matching how this repo's other CI-consumed test
+// artifacts are laid out under test-results/.
+func writeTraceArtifact(t *testing.T, data []byte) {
+	t.Helper()
+	outDir := filepath.Join("..", "test-results", "rdp-trace")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatalf("failed to create trace output dir %s: %v", outDir, err)
+	}
+	outPath := filepath.Join(outDir, "trace.jsonl")
+	if err := os.WriteFile(outPath, data, 0o644); err != nil {
+		t.Fatalf("failed to write trace artifact %s: %v", outPath, err)
+	}
+}


### PR DESCRIPTION
## Summary
PR 1 of 3 for trace-based runtime verification of the RDP accountant (see plan discussed with the repo owner). The Refinement layer currently only checks Lean<->Go correspondence on four fixed test vectors ([row 13](proofs/FORMAL_TRACEABILITY_MATRIX.md) of the traceability matrix), which says nothing about a live, dynamic call sequence the way the accountant actually runs in production.

- Adds `RDPAccountant.TraceSink` (`io.Writer`, nil by default -- strictly opt-in, zero behavior change and zero overhead when untraced).
- When set, `RecordStepRat`/`RecordShardStepRat`/`CheckBudget` each emit one JSONL `TraceEvent` line with exact rational values (`RatString()`, not `float64`) so a downstream Lean validator (next PR) can compare exactly -- the same precision bar the four pinned vectors already use.
- `CheckBudget`'s conversion term (`log(1/delta)/(alpha-1)`, computed via `math.Log`) is recorded as informational only: Lean's `Real.log` is noncomputable, so a validator can't independently re-derive it. What it *can* and will check is that `BudgetOK` follows correctly from the exact ledger value plus that recorded term -- i.e. that the decision was actually computed from the same ledger Lean's replay independently arrives at, not a stale or diverged one.
- New `test/rdp_accountant_trace_test.go` drives a real multi-shard, multi-round scenario (three shards, a budget check after each, then a deliberate over-budget push) through the real accountant and writes the trace to `test-results/rdp-trace/trace.jsonl` -- the input for the Lean validator landing in PR 2.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./internal/... ./test/...` clean
- [x] `gofmt -l` clean on all touched/new files
- [x] `go test ./test -run 'RDPAccountant' -v` -- all 10 subtests pass, including the new trace test, no regressions to existing RDPAccountant coverage
- [x] Manually inspected the generated `trace.jsonl`: exact rational values throughout, correct cumulative sums, `budget_ok` correctly flips `true` -> `false` only at the deliberate overage