### PR TITLE
feat(formal-verification): Lean trace validator for the RDP accountant

### DIFF
--- a/proofs/TraceValidator/RDPAccountant.lean
+++ b/proofs/TraceValidator/RDPAccountant.lean
@@ -1,0 +1,158 @@
+import Lean.Data.Json
+import Refinement.RDPAccountant
+
+/-!
+# RDP Accountant Trace Validator
+
+Replays a JSONL execution trace of `internal.RDPAccountant` (recorded via
+its `TraceSink`, see `internal/rdp_trace.go` and
+`test/rdp_accountant_trace_test.go`) through the already-proven
+`Specification.composeRDP` / `Refinement.accountantImpl` ledger model and
+checks the two things a live trace can establish that the four fixed test
+vectors cited in `FORMAL_TRACEABILITY_MATRIX.md` row 13 cannot:
+
+1. The Lean ledger model matches Go's `TotalEpsilon` exactly across an
+   arbitrary, dynamic sequence of `record_step`/`record_shard_step` calls
+   (not just four pinned scenarios) — exact rational comparison, since
+   both sides use exact rational arithmetic (`RatString()` on the Go side,
+   `Rat` here).
+2. Every `check_budget` event's recorded `budget_ok` is the correct
+   conclusion from that same exact ledger value plus Go's own recorded
+   conversion term, against `max_budget` — i.e. `CheckBudget` really was
+   computed from the ledger this replay independently arrives at, not a
+   stale or diverged one.
+
+This does **not** independently re-derive Go's `log(1/δ)/(α-1)` conversion
+term: `Real.log` is noncomputable in Lean, so that formula itself remains
+outside what any executable can check — see `Refinement.rdpToApproxDP` /
+`Refinement.rdp_budget_conversion_shift`, which formalize its *shape* and
+properties, not a numeric value. `conversion_term` is taken from the trace
+as Go's own value and used only to check internal consistency of the
+recorded decision against the independently-replayed ledger, not to
+validate the conversion formula itself.
+
+Usage: `rdp_trace_validator <path-to-trace.jsonl>`
+-/
+
+open Lean Specification Refinement
+
+namespace TraceValidator
+
+/-- Parse a Go `big.Rat.RatString()` value (`"a"` or `"a/b"`, optional
+leading `-`) into a `Rat`. `Rat.divInt` normalizes automatically, so no
+coprimality/positivity proof obligations arise here. -/
+def parseRat (s : String) : Except String Rat :=
+  match s.splitOn "/" with
+  | [n] =>
+      match n.toInt? with
+      | some num => .ok (Rat.divInt num 1)
+      | none => .error s!"invalid integer literal: {s}"
+  | [n, d] =>
+      match n.toInt?, d.toInt? with
+      | some num, some den => .ok (Rat.divInt num den)
+      | _, _ => .error s!"invalid rational literal: {s}"
+  | _ => .error s!"unexpected rational format: {s}"
+
+def getStrField (j : Json) (field : String) : Except String String :=
+  (j.getObjValD field).getStr?
+
+def getBoolField (j : Json) (field : String) : Except String Bool :=
+  (j.getObjValD field).getBool?
+
+def getRatField (j : Json) (field : String) : Except String Rat := do
+  let s ← getStrField j field
+  parseRat s
+
+/-- Running validator state: the flat list of every `record_step` /
+`record_shard_step` epsilon seen so far, in trace order. Grouping into
+shards vs. a flat sequence doesn't affect `accountantImpl`'s total (that's
+exactly what `accountant_impl_append` proves), so a single flat list is
+sufficient to replay the whole ledger. -/
+structure ValidatorState where
+  steps         : List Rat := []
+  lineNo        : Nat := 0
+  checkedRecords : Nat := 0
+  checkedBudgets : Nat := 0
+
+/-- Print a diagnostic and exit nonzero. Polymorphic return type: `main`
+never returns from `IO.Process.exit`, so this can be used anywhere an
+`IO α` is expected regardless of `α`. -/
+def fail (state : ValidatorState) (msg : String) : IO α := do
+  IO.eprintln s!"line {state.lineNo}: {msg}"
+  IO.Process.exit 1
+
+/-- Process one already-parsed JSON trace event, updating state or failing
+loudly with a diagnostic on any mismatch. -/
+def step (state : ValidatorState) (j : Json) : IO ValidatorState := do
+  let event ← match getStrField j "event" with
+    | .ok e => pure e
+    | .error e => fail state s!"missing/invalid 'event' field: {e}"
+  match event with
+  | "record_step" | "record_shard_step" =>
+      let eps ← match getRatField j "epsilon" with
+        | .ok r => pure r
+        | .error e => fail state s!"invalid 'epsilon': {e}"
+      let want ← match getRatField j "cumulative_epsilon" with
+        | .ok r => pure r
+        | .error e => fail state s!"invalid 'cumulative_epsilon': {e}"
+      let newSteps := state.steps ++ [eps]
+      let got := accountantImpl newSteps
+      if got ≠ want then
+        fail state
+          s!"ledger mismatch after {event}: accountantImpl replay = {repr got}, trace recorded cumulative_epsilon = {repr want}"
+      pure { state with steps := newSteps, checkedRecords := state.checkedRecords + 1 }
+  | "check_budget" =>
+      let cumulative ← match getRatField j "cumulative_epsilon" with
+        | .ok r => pure r
+        | .error e => fail state s!"invalid 'cumulative_epsilon': {e}"
+      let maxBudget ← match getRatField j "max_budget" with
+        | .ok r => pure r
+        | .error e => fail state s!"invalid 'max_budget': {e}"
+      let conversion ← match getRatField j "conversion_term" with
+        | .ok r => pure r
+        | .error e => fail state s!"invalid 'conversion_term': {e}"
+      let budgetOk ← match getBoolField j "budget_ok" with
+        | .ok b => pure b
+        | .error e => fail state s!"invalid 'budget_ok': {e}"
+      -- Cross-check the trace's own recorded ledger snapshot against the
+      -- independent replay before trusting it for the budget check below.
+      let replayed := accountantImpl state.steps
+      if replayed ≠ cumulative then
+        fail state
+          s!"check_budget's own recorded cumulative_epsilon ({repr cumulative}) disagrees with the ledger replayed from prior record events ({repr replayed})"
+      let leanExceeds := decide (cumulative + conversion > maxBudget)
+      -- budgetOk should be exactly (not leanExceeds); a match means they
+      -- disagree.
+      if leanExceeds = budgetOk then
+        fail state
+          s!"check_budget mismatch: cumulative_epsilon ({repr cumulative}) + conversion_term ({repr conversion}) vs max_budget ({repr maxBudget}) implies budget_ok = {!leanExceeds}, but trace recorded budget_ok = {budgetOk}"
+      pure { state with checkedBudgets := state.checkedBudgets + 1 }
+  | other => fail state s!"unknown event type: {other}"
+
+/-- Read `path`, replay every JSONL line through `step`, and report a
+summary on success (any failure exits nonzero from within `step`/`fail`
+before this returns). -/
+partial def run (path : System.FilePath) : IO Unit := do
+  let contents ← IO.FS.readFile path
+  let lines := (contents.splitOn "\n").filter (fun l => !l.trimAscii.isEmpty)
+  if lines.isEmpty then
+    IO.eprintln s!"trace file {path} contained no events"
+    IO.Process.exit 1
+  let mut state : ValidatorState := {}
+  for line in lines do
+    state := { state with lineNo := state.lineNo + 1 }
+    match Json.parse line with
+    | .error e => fail state s!"JSON parse error: {e}"
+    | .ok j =>
+        state ← step state j
+  IO.println
+    s!"OK: {state.checkedRecords} record event(s), {state.checkedBudgets} check_budget event(s), all matched the Lean ledger replay exactly."
+
+end TraceValidator
+
+def main (args : List String) : IO Unit := do
+  match args with
+  | [path] => TraceValidator.run path
+  | _ =>
+      IO.eprintln "usage: rdp_trace_validator <path-to-trace.jsonl>"
+      IO.Process.exit 2

--- a/proofs/lakefile.lean
+++ b/proofs/lakefile.lean
@@ -19,3 +19,17 @@ lean_lib Specification where
 
 @[default_target]
 lean_lib Refinement where
+
+-- TraceValidator/RDPAccountant.lean (PR 2 of the trace-based-runtime-
+-- verification effort) is deliberately NOT declared as a `lean_exe`
+-- target here. `Refinement.RDPAccountant` pulls in the unrestricted
+-- `import Mathlib`, and a `lean_exe` needs the whole transitive import
+-- closure natively compiled to object code for linking -- unlike a
+-- `lean_lib`, which only needs `.olean` interface files. Attempting
+-- `lake build` on a `lean_exe` here triggered ~16600 native Mathlib C
+-- compilation steps (most of them entirely unrelated to RDPAccountant)
+-- and did not finish in a reasonable time. Interpreted execution avoids
+-- this entirely and reuses the same `.olean` cache the `lean_lib` targets
+-- above already warm: `lake env lean --run TraceValidator/
+-- RDPAccountant.lean <path-to-trace.jsonl>` -- see that file's usage
+-- comment and the CI workflow that invokes it this way.


### PR DESCRIPTION
## Summary
PR 2 of 3 for trace-based runtime verification of the RDP accountant (PR 1: [#152](https://github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/pull/152)). This PR is pure Lean and has no code dependency on PR 1 (it just needs a `trace.jsonl` file at runtime, produced by PR 1's Go instrumentation) -- logically sequenced after it, but independently reviewable.

- New `proofs/TraceValidator/RDPAccountant.lean`: replays a JSONL trace through the already-proven `Specification.composeRDP` / `Refinement.accountantImpl` ledger model. Checks (1) the ledger replay matches Go's `TotalEpsilon` exactly across an arbitrary dynamic call sequence (not just the four fixed vectors in [row 13](proofs/FORMAL_TRACEABILITY_MATRIX.md)), and (2) every `check_budget` event's recorded `budget_ok` follows correctly from that same exact ledger plus Go's own recorded conversion term. Does **not** independently re-derive Go's `log(1/delta)/(alpha-1)` conversion formula -- `Real.log` is noncomputable in Lean, so that stays scoped to `rdpToApproxDP`/`rdp_budget_conversion_shift`'s already-proven shape/properties, not a numeric re-derivation. Full reasoning in the file's own doc comment.

## Real finding worth flagging
Declaring this as a `lean_exe` (the originally-planned approach) triggered Lake to natively compile the **entire transitive Mathlib import closure** to object code for linking -- ~16,600 build steps, did not finish in a reasonable time locally. A `lean_exe` needs full native compilation of everything it imports; a `lean_lib` only needs `.olean` interface files. `Refinement.RDPAccountant`'s unrestricted `import Mathlib` made the `lean_exe` route catastrophically expensive.

Switched to interpreted execution instead: `lake env lean --run TraceValidator/RDPAccountant.lean <trace-path>`, which reuses the same `.olean` cache the existing `lean_lib` targets already warm and runs in seconds. No `lean_exe` target in the lakefile -- see the comment left there explaining why.

## Test plan
- [x] Generated a real trace via PR 1's `TestRDPAccountantTrace` and ran the validator against it: `OK: 7 record event(s), 4 check_budget event(s), all matched the Lean ledger replay exactly.`
- [x] Hand-corrupted one `epsilon` value in the trace (leaving its stale `cumulative_epsilon` unchanged) -- validator correctly failed: `line 2: ledger mismatch after record_shard_step: accountantImpl replay = 13/100, trace recorded cumulative_epsilon = 11/100`
- [x] Hand-flipped one `budget_ok` decision -- validator correctly failed: `line 11: check_budget mismatch: ... implies budget_ok = false, but trace recorded budget_ok = true`
- [x] `lake build LeanFormalization Specification Refinement` still succeeds (lakefile edit didn't break existing targets)
- [x] `lint_formal_proof_claims.py`, `validate_formal_traceability.sh`, `check_markdown_links.py` all still pass locally