### PR TITLE
feat(formal-verification): hierarchical BFT simulator core (no tracing yet)

### DIFF
--- a/internal/hbft/adversary.go
+++ b/internal/hbft/adversary.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Sovereign-Mohawk Core Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hbft
+
+import "math/rand/v2"
+
+// AdversaryStrategy crafts submitted gradients for a round's Byzantine
+// committee members. honestGradients gives the strategy visibility into
+// what honest members are submitting this round: a worst-case assumption
+// (a real attacker might not have this), but assuming it does is what
+// makes a passing trace validator's cross-check meaningful against a
+// genuinely adaptive attacker rather than a strawman that Multi-Krum's
+// distance-based scoring would filter trivially.
+type AdversaryStrategy interface {
+	Craft(rng *rand.Rand, dimension int, honestGradients [][]float64, byzantineCount int) [][]float64
+}
+
+// OutlierAdversary submits gradients far from the honest cluster in every
+// dimension -- trivially filtered by Multi-Krum's distance-based scoring.
+// Mirrors the existing internal/multikrum_test.go fixture style. Useful
+// as a sanity baseline, not the interesting case.
+type OutlierAdversary struct {
+	Magnitude float64
+}
+
+func (a OutlierAdversary) Craft(_ *rand.Rand, dimension int, _ [][]float64, byzantineCount int) [][]float64 {
+	out := make([][]float64, byzantineCount)
+	for i := range out {
+		g := make([]float64, dimension)
+		for d := range g {
+			g[d] = a.Magnitude
+		}
+		out[i] = g
+	}
+	return out
+}
+
+// CollusionAdversary biases Byzantine members' gradients toward a shared
+// target offset from the honest cluster's centroid, with small per-node
+// jitter so colluding submissions aren't bit-identical. This is the
+// interesting case: colluding nodes that agree with each other look like
+// a legitimate cluster to Krum's neighbor-distance scoring unless the
+// bias is large enough to separate them from the honest cluster --
+// exactly the attack Multi-Krum's guarantee is actually about, not a
+// strawman far-outlier.
+type CollusionAdversary struct {
+	Bias float64
+}
+
+func (a CollusionAdversary) Craft(rng *rand.Rand, dimension int, honestGradients [][]float64, byzantineCount int) [][]float64 {
+	target := centroidOf(honestGradients, dimension)
+	for d := range target {
+		target[d] += a.Bias
+	}
+	out := make([][]float64, byzantineCount)
+	for i := range out {
+		g := make([]float64, dimension)
+		copy(g, target)
+		for d := range g {
+			g[d] += (rng.Float64() - 0.5) * 0.01
+		}
+		out[i] = g
+	}
+	return out
+}
+
+func centroidOf(gradients [][]float64, dimension int) []float64 {
+	c := make([]float64, dimension)
+	for _, g := range gradients {
+		for d := 0; d < dimension; d++ {
+			c[d] += g[d]
+		}
+	}
+	if len(gradients) > 0 {
+		for d := range c {
+			c[d] /= float64(len(gradients))
+		}
+	}
+	return c
+}

--- a/internal/hbft/committee.go
+++ b/internal/hbft/committee.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Sovereign-Mohawk Core Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hbft
+
+// TopologyConfig describes the static shape of the hierarchy: how many
+// tiers, how many committees per tier, and how many nodes per committee.
+// Node *identity* within that shape is fixed for the whole simulation
+// (see Simulator.nodes); committee *membership* is resampled every round
+// (see Simulator.RunRound) -- matching the i.i.d.-per-round committee
+// sampling proofs/LeanFormalization/Theorem4ChernoffBounds.lean's tail
+// bound assumes, not a fixed static partition.
+//
+// Tiers are independent, parallel groups of committees over their own
+// disjoint node sub-pool -- not a nested aggregation pipeline where a
+// higher tier processes a lower tier's output. proofs/TraceValidator/
+// HierarchicalBFT.lean's CommitteeOutcome/TierAccumulator design (see the
+// implementation plan) treats every committee, at every tier, uniformly
+// as one independent group of leaf-level, ground-truth-labeled nodes --
+// "a committee plays the role one HTree.leaf-bearing subtree does" -- so
+// a real recursive multi-level aggregation pipeline (higher tiers
+// processing lower tiers' aggregate outputs) isn't what this simulator
+// needs to build, and inventing one would be an arbitrary design choice
+// with no existing spec to ground it in. Multiple tiers exist here purely
+// to exercise the same committee-safety mechanic at multiple independent
+// scales in a single run, not to model a literal aggregation hierarchy.
+type TopologyConfig struct {
+	Tiers             int
+	CommitteesPerTier int
+	NodesPerCommittee int
+}
+
+// TotalNodes is the total simulated population size implied by cfg: each
+// tier gets its own disjoint sub-pool of CommitteesPerTier *
+// NodesPerCommittee nodes.
+func (cfg TopologyConfig) TotalNodes() int {
+	return cfg.Tiers * cfg.CommitteesPerTier * cfg.NodesPerCommittee
+}
+
+// Committee is one committee's realized membership for a single round.
+type Committee struct {
+	ID      string
+	TierID  int
+	Members []NodeID
+}
+
+// Tier is one round's realized set of committees for a given tier.
+type Tier struct {
+	ID         int
+	Committees []Committee
+}

--- a/internal/hbft/node.go
+++ b/internal/hbft/node.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Sovereign-Mohawk Core Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package hbft is a stateful, multi-round hierarchical Multi-Krum
+// simulator built for trace-based runtime verification of
+// proofs/FORMAL_TRACEABILITY_MATRIX.md row 1. It exists purely to drive
+// realistic, evolving inputs into the real production selection algorithm
+// (internal.MultiKrumSelect); it does not reimplement or approximate
+// selection itself.
+package hbft
+
+// NodeID identifies a simulated node. Stable across rounds -- unlike
+// scripts/byzantine_10m_validation/main.go, which recreates shards (and
+// so node identity) every round, this package treats node identity and
+// its ground-truth Byzantine label as persistent state, matching how a
+// real deployment's set of participants doesn't get re-rolled each round.
+type NodeID uint64
+
+// NodeState is a node's persistent identity and ground-truth label. Real
+// production code (internal.MultiKrumSelect) never sees IsByzantine --
+// it exists here purely as the simulator's planted ground truth for
+// verification. See trace.go (added in a later PR) for how this is
+// exposed in the execution trace and why that's safe (verification-only,
+// never present when tracing is disabled).
+type NodeState struct {
+	ID          NodeID
+	TierID      int
+	IsByzantine bool
+}

--- a/internal/hbft/simulator.go
+++ b/internal/hbft/simulator.go
@@ -1,0 +1,254 @@
+// Copyright 2026 Sovereign-Mohawk Core Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hbft
+
+import (
+	"fmt"
+	"math/rand/v2"
+
+	"github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/internal"
+	"github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/internal/hva"
+)
+
+// SimulatorConfig configures a Simulator run.
+type SimulatorConfig struct {
+	Topology      TopologyConfig
+	ByzantineRate float64 // fraction of each tier's node pool marked Byzantine at construction (ground truth, fixed for the run)
+	Adversary     AdversaryStrategy
+	Dimension     int
+	Seed          uint64
+}
+
+// CommitteeResult is one committee's realized outcome for one round.
+type CommitteeResult struct {
+	Committee Committee
+	// Labels is ground truth (same order as Committee.Members), never
+	// seen by internal.MultiKrumSelect itself -- see node.go.
+	Labels      []bool
+	Gradients   [][]float64
+	ByzantineF  int
+	SelectedIdx []int
+	// LocallySafe is a pure ground-truth composition fact -- 2*honest >
+	// total -- independent of what MultiKrumSelect actually selected.
+	// This is deliberately the same rule
+	// proofs/LeanFormalization/Theorem1BFT.lean's HTree.safe states: local
+	// safety is about committee composition, not about any particular
+	// selection algorithm's output. See TierResult.SafeLeafWeight for how
+	// this gets (mis)credited upward -- the exact mechanism
+	// hierarchical_composition_counterexample proves does not compose
+	// soundly in general.
+	LocallySafe bool
+}
+
+// TierResult is one tier's realized outcome for one round.
+type TierResult struct {
+	TierID          int
+	Committees      []CommitteeResult
+	TotalLeaves     int
+	ByzantineLeaves int
+	SafeLeafWeight  int
+}
+
+// RoundResult is one round's full realized outcome.
+type RoundResult struct {
+	Round int
+	Seed  uint64 // base config seed; combined with Round, fully determines this round's RNG stream
+	Tiers []TierResult
+	// RootSafe is true iff every tier's SafeLeafWeight credits a majority
+	// of that tier's TotalLeaves. A simple top-level combination across
+	// tiers, not a recursive multi-level fold -- see committee.go's
+	// TopologyConfig doc comment for why tiers are independent here
+	// rather than a nested aggregation pipeline.
+	RootSafe bool
+}
+
+// Simulator drives realistic, evolving inputs into the real production
+// internal.MultiKrumSelect across many rounds. Node identity and each
+// node's ground-truth IsByzantine label are fixed at construction and
+// persist across rounds (internal.MultiKrumSelect never sees these
+// labels); committee membership is resampled every round.
+type Simulator struct {
+	cfg       SimulatorConfig
+	nodes     map[NodeID]*NodeState
+	tierPools [][]NodeID // per-tier node pool, resampled into committees each round
+	round     int
+}
+
+// NewSimulator builds a Simulator and plants each tier's node population
+// with cfg.ByzantineRate fraction marked Byzantine (ground truth, fixed
+// for the run). Deterministic given cfg.Seed.
+func NewSimulator(cfg SimulatorConfig) (*Simulator, error) {
+	if cfg.Topology.Tiers <= 0 || cfg.Topology.CommitteesPerTier <= 0 || cfg.Topology.NodesPerCommittee <= 0 {
+		return nil, fmt.Errorf("hbft: topology dimensions must be positive: %+v", cfg.Topology)
+	}
+	if cfg.ByzantineRate < 0 || cfg.ByzantineRate >= 1 {
+		return nil, fmt.Errorf("hbft: byzantine rate must be in [0,1): %f", cfg.ByzantineRate)
+	}
+	if cfg.Adversary == nil {
+		return nil, fmt.Errorf("hbft: adversary strategy required")
+	}
+	if cfg.Dimension <= 0 {
+		return nil, fmt.Errorf("hbft: dimension must be positive")
+	}
+	// internal.MultiKrumSelect requires n > 2f+2; f is derived per
+	// committee from hva.MaximumByzantineNodes(NodesPerCommittee), the
+	// same 5/9-derived bound the rest of this repo uses (not a reinvented
+	// number) -- verify the chosen topology actually satisfies
+	// MultiKrumSelect's real precondition now, rather than discovering
+	// that as an opaque runtime error mid-simulation.
+	f := hva.MaximumByzantineNodes(cfg.Topology.NodesPerCommittee)
+	if cfg.Topology.NodesPerCommittee <= 2*f+2 {
+		return nil, fmt.Errorf(
+			"hbft: NodesPerCommittee=%d yields f=%d via hva.MaximumByzantineNodes, "+
+				"violating MultiKrumSelect's n > 2f+2 precondition (need NodesPerCommittee > %d)",
+			cfg.Topology.NodesPerCommittee, f, 2*f+2)
+	}
+
+	rng := rand.New(rand.NewPCG(cfg.Seed, 0))
+	nodes := make(map[NodeID]*NodeState, cfg.Topology.TotalNodes())
+	tierPools := make([][]NodeID, cfg.Topology.Tiers)
+	var nextID NodeID
+	tierSize := cfg.Topology.CommitteesPerTier * cfg.Topology.NodesPerCommittee
+	for t := 0; t < cfg.Topology.Tiers; t++ {
+		pool := make([]NodeID, 0, tierSize)
+		for i := 0; i < tierSize; i++ {
+			id := nextID
+			nextID++
+			isByz := rng.Float64() < cfg.ByzantineRate
+			nodes[id] = &NodeState{ID: id, TierID: t, IsByzantine: isByz}
+			pool = append(pool, id)
+		}
+		tierPools[t] = pool
+	}
+
+	return &Simulator{cfg: cfg, nodes: nodes, tierPools: tierPools}, nil
+}
+
+// RunRound executes one round: resamples committee membership per tier,
+// generates gradients (honest via a small-noise cluster, Byzantine via
+// cfg.Adversary), calls the real internal.MultiKrumSelect per committee,
+// and folds outcomes into per-tier weighted-safety bookkeeping mirroring
+// HTree.safe's credited-weight rule.
+func (s *Simulator) RunRound() (RoundResult, error) {
+	rng := rand.New(rand.NewPCG(s.cfg.Seed, uint64(s.round)))
+
+	result := RoundResult{Round: s.round, Seed: s.cfg.Seed}
+	allSafe := true
+
+	for t := 0; t < s.cfg.Topology.Tiers; t++ {
+		pool := append([]NodeID(nil), s.tierPools[t]...)
+		rng.Shuffle(len(pool), func(i, j int) { pool[i], pool[j] = pool[j], pool[i] })
+
+		tierResult := TierResult{TierID: t}
+		for c := 0; c < s.cfg.Topology.CommitteesPerTier; c++ {
+			start := c * s.cfg.Topology.NodesPerCommittee
+			members := pool[start : start+s.cfg.Topology.NodesPerCommittee]
+
+			cr, err := s.runCommittee(rng, t, c, members)
+			if err != nil {
+				return RoundResult{}, err
+			}
+			tierResult.Committees = append(tierResult.Committees, cr)
+			tierResult.TotalLeaves += len(cr.Labels)
+			tierResult.ByzantineLeaves += countTrue(cr.Labels)
+			if cr.LocallySafe {
+				tierResult.SafeLeafWeight += len(cr.Labels)
+			}
+		}
+		if 2*tierResult.SafeLeafWeight <= tierResult.TotalLeaves {
+			allSafe = false
+		}
+		result.Tiers = append(result.Tiers, tierResult)
+	}
+	result.RootSafe = allSafe
+
+	s.round++
+	return result, nil
+}
+
+func (s *Simulator) runCommittee(rng *rand.Rand, tierID, committeeIdx int, members []NodeID) (CommitteeResult, error) {
+	labels := make([]bool, len(members))
+	var honestIdx, byzIdx []int
+	for i, id := range members {
+		labels[i] = s.nodes[id].IsByzantine
+		if labels[i] {
+			byzIdx = append(byzIdx, i)
+		} else {
+			honestIdx = append(honestIdx, i)
+		}
+	}
+
+	gradients := make([][]float64, len(members))
+	honestGradients := make([][]float64, 0, len(honestIdx))
+	for _, i := range honestIdx {
+		g := make([]float64, s.cfg.Dimension)
+		for d := range g {
+			g[d] = 1.0 + (rng.Float64()-0.5)*0.02 // small-noise cluster
+		}
+		gradients[i] = g
+		honestGradients = append(honestGradients, g)
+	}
+	if len(byzIdx) > 0 {
+		byzGradients := s.cfg.Adversary.Craft(rng, s.cfg.Dimension, honestGradients, len(byzIdx))
+		for k, i := range byzIdx {
+			gradients[i] = byzGradients[k]
+		}
+	}
+
+	f := hva.MaximumByzantineNodes(len(members))
+	selected, _, err := internal.MultiKrumSelect(gradients, f, 0)
+	if err != nil {
+		return CommitteeResult{}, fmt.Errorf("hbft: MultiKrumSelect failed for tier %d committee %d: %w", tierID, committeeIdx, err)
+	}
+
+	byzCount := countTrue(labels)
+	locallySafe := 2*(len(members)-byzCount) > len(members)
+
+	return CommitteeResult{
+		Committee: Committee{
+			ID:      fmt.Sprintf("t%d-c%d", tierID, committeeIdx),
+			TierID:  tierID,
+			Members: append([]NodeID(nil), members...),
+		},
+		Labels:      labels,
+		Gradients:   gradients,
+		ByzantineF:  f,
+		SelectedIdx: selected,
+		LocallySafe: locallySafe,
+	}, nil
+}
+
+func countTrue(bs []bool) int {
+	n := 0
+	for _, b := range bs {
+		if b {
+			n++
+		}
+	}
+	return n
+}
+
+// Run executes rounds sequentially and returns all results.
+func (s *Simulator) Run(rounds int) ([]RoundResult, error) {
+	results := make([]RoundResult, 0, rounds)
+	for i := 0; i < rounds; i++ {
+		r, err := s.RunRound()
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, r)
+	}
+	return results, nil
+}

--- a/internal/hbft/simulator_test.go
+++ b/internal/hbft/simulator_test.go
@@ -1,0 +1,205 @@
+// Copyright 2026 Sovereign-Mohawk Core Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hbft
+
+import "testing"
+
+func testTopology() TopologyConfig {
+	// NodesPerCommittee=27 comfortably satisfies MultiKrumSelect's
+	// n > 2f+2 precondition at the hva-derived f=12 (2f+2=26 < 27).
+	return TopologyConfig{Tiers: 3, CommitteesPerTier: 6, NodesPerCommittee: 27}
+}
+
+func TestNewSimulator_RejectsUnsafeTopology(t *testing.T) {
+	// NodesPerCommittee=18 yields f=8 via hva.MaximumByzantineNodes,
+	// 2f+2=18, violating MultiKrumSelect's n > 2f+2 precondition.
+	_, err := NewSimulator(SimulatorConfig{
+		Topology:      TopologyConfig{Tiers: 1, CommitteesPerTier: 1, NodesPerCommittee: 18},
+		ByzantineRate: 0.2,
+		Adversary:     OutlierAdversary{Magnitude: 100},
+		Dimension:     4,
+		Seed:          1,
+	})
+	if err == nil {
+		t.Fatal("expected NewSimulator to reject a topology violating MultiKrumSelect's n > 2f+2 precondition")
+	}
+}
+
+func TestSimulator_RunRound_CallsRealMultiKrumSelect(t *testing.T) {
+	sim, err := NewSimulator(SimulatorConfig{
+		Topology:      testTopology(),
+		ByzantineRate: 0.2,
+		Adversary:     OutlierAdversary{Magnitude: 100},
+		Dimension:     4,
+		Seed:          42,
+	})
+	if err != nil {
+		t.Fatalf("NewSimulator failed: %v", err)
+	}
+
+	result, err := sim.RunRound()
+	if err != nil {
+		t.Fatalf("RunRound failed: %v", err)
+	}
+
+	if len(result.Tiers) != 3 {
+		t.Fatalf("expected 3 tiers, got %d", len(result.Tiers))
+	}
+	for _, tier := range result.Tiers {
+		if len(tier.Committees) != 6 {
+			t.Fatalf("tier %d: expected 6 committees, got %d", tier.TierID, len(tier.Committees))
+		}
+		for _, c := range tier.Committees {
+			if len(c.Committee.Members) != 27 {
+				t.Fatalf("committee %s: expected 27 members, got %d", c.Committee.ID, len(c.Committee.Members))
+			}
+			if len(c.SelectedIdx) == 0 {
+				t.Fatalf("committee %s: MultiKrumSelect returned no selected indices", c.Committee.ID)
+			}
+			for _, idx := range c.SelectedIdx {
+				if idx < 0 || idx >= len(c.Committee.Members) {
+					t.Fatalf("committee %s: selected index %d out of range", c.Committee.ID, idx)
+				}
+			}
+		}
+	}
+
+	// With an outlier adversary at Magnitude=100 far from the honest
+	// cluster's ~1.0 centroid, real MultiKrumSelect should exclude
+	// Byzantine members from every committee's selection -- this is the
+	// actual production algorithm doing real filtering, not a stub.
+	for _, tier := range result.Tiers {
+		for _, c := range tier.Committees {
+			for _, idx := range c.SelectedIdx {
+				if c.Labels[idx] {
+					t.Fatalf("committee %s: MultiKrumSelect selected a labeled-Byzantine outlier at index %d", c.Committee.ID, idx)
+				}
+			}
+		}
+	}
+}
+
+func TestSimulator_CommitteeMembershipResamplesEachRound(t *testing.T) {
+	sim, err := NewSimulator(SimulatorConfig{
+		Topology:      testTopology(),
+		ByzantineRate: 0.2,
+		Adversary:     OutlierAdversary{Magnitude: 100},
+		Dimension:     4,
+		Seed:          7,
+	})
+	if err != nil {
+		t.Fatalf("NewSimulator failed: %v", err)
+	}
+
+	r1, err := sim.RunRound()
+	if err != nil {
+		t.Fatalf("round 1 failed: %v", err)
+	}
+	r2, err := sim.RunRound()
+	if err != nil {
+		t.Fatalf("round 2 failed: %v", err)
+	}
+
+	same := true
+	for i := range r1.Tiers[0].Committees[0].Committee.Members {
+		if r1.Tiers[0].Committees[0].Committee.Members[i] != r2.Tiers[0].Committees[0].Committee.Members[i] {
+			same = false
+			break
+		}
+	}
+	if same {
+		t.Fatal("expected committee membership to differ across rounds (resampled each round), but round 1 and round 2 committee 0 were identical")
+	}
+}
+
+func TestSimulator_DeterministicGivenSeed(t *testing.T) {
+	cfg := SimulatorConfig{
+		Topology:      testTopology(),
+		ByzantineRate: 0.2,
+		Adversary:     OutlierAdversary{Magnitude: 100},
+		Dimension:     4,
+		Seed:          123,
+	}
+
+	simA, err := NewSimulator(cfg)
+	if err != nil {
+		t.Fatalf("NewSimulator (A) failed: %v", err)
+	}
+	simB, err := NewSimulator(cfg)
+	if err != nil {
+		t.Fatalf("NewSimulator (B) failed: %v", err)
+	}
+
+	rounds, err := simA.Run(3)
+	if err != nil {
+		t.Fatalf("simA.Run failed: %v", err)
+	}
+	roundsB, err := simB.Run(3)
+	if err != nil {
+		t.Fatalf("simB.Run failed: %v", err)
+	}
+
+	if len(rounds) != len(roundsB) {
+		t.Fatalf("round count mismatch: %d vs %d", len(rounds), len(roundsB))
+	}
+	for i := range rounds {
+		a, b := rounds[i], roundsB[i]
+		if a.RootSafe != b.RootSafe {
+			t.Fatalf("round %d: RootSafe mismatch between identically-seeded runs: %v vs %v", i, a.RootSafe, b.RootSafe)
+		}
+		for ti := range a.Tiers {
+			if a.Tiers[ti].SafeLeafWeight != b.Tiers[ti].SafeLeafWeight {
+				t.Fatalf("round %d tier %d: SafeLeafWeight mismatch between identically-seeded runs: %d vs %d",
+					i, ti, a.Tiers[ti].SafeLeafWeight, b.Tiers[ti].SafeLeafWeight)
+			}
+			for ci := range a.Tiers[ti].Committees {
+				ca, cb := a.Tiers[ti].Committees[ci], b.Tiers[ti].Committees[ci]
+				if len(ca.Committee.Members) != len(cb.Committee.Members) {
+					t.Fatalf("round %d tier %d committee %d: member count mismatch", i, ti, ci)
+				}
+				for mi := range ca.Committee.Members {
+					if ca.Committee.Members[mi] != cb.Committee.Members[mi] {
+						t.Fatalf("round %d tier %d committee %d: member %d differs between identically-seeded runs", i, ti, ci, mi)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestSimulator_CollusionAdversary(t *testing.T) {
+	sim, err := NewSimulator(SimulatorConfig{
+		Topology:      testTopology(),
+		ByzantineRate: 0.2,
+		Adversary:     CollusionAdversary{Bias: 5.0},
+		Dimension:     4,
+		Seed:          99,
+	})
+	if err != nil {
+		t.Fatalf("NewSimulator failed: %v", err)
+	}
+
+	result, err := sim.RunRound()
+	if err != nil {
+		t.Fatalf("RunRound failed: %v", err)
+	}
+	if len(result.Tiers) == 0 {
+		t.Fatal("expected at least one tier")
+	}
+	// Just confirm the run completes and produces well-formed output --
+	// unlike the far-outlier case, collusion at a moderate bias isn't
+	// guaranteed to always be filtered, and that's the point (it's the
+	// interesting case, not something this test should assert away).
+}


### PR DESCRIPTION
## Summary
PR 1 of 6 for trace-based runtime verification of row 1's flagship hierarchical Multi-Krum claim (55.5% Byzantine resilience). Confirmed via deep exploration this session: no existing Go infrastructure calls the real `MultiKrumSelect` with stateful, multi-round, adversarial input. `internal/batch/aggregator.go`'s `ProcessRound` (what `swarm-runtime-matrix.yml` exercises) never touches MultiKrum at all -- its pass/fail gate is a pure node-count threshold check. The one round-loop script (`scripts/byzantine_10m_validation/main.go`) isn't CI-wired, doesn't call the real `MultiKrumSelect`, and uses fake pseudo-random "detection."

New package `internal/hbft`:
- `node.go` -- `NodeID`/`NodeState` with a ground-truth `IsByzantine` label, persistent across rounds (unlike `byzantine_10m_validation`'s per-round shard recreation).
- `committee.go` -- `TopologyConfig`/`Committee`/`Tier`. Tiers are independent, parallel committee groups over disjoint node sub-pools, **not** a nested aggregation pipeline -- matches how the planned Lean validator's `CommitteeOutcome`/`TierAccumulator` design treats every committee uniformly as one `HTree.leaf`-bearing-subtree equivalent, and avoids inventing an unspecified multi-level aggregation mechanism this repo has no existing spec for.
- `adversary.go` -- `AdversaryStrategy` interface, `OutlierAdversary` (trivial, mirrors existing `multikrum_test.go` fixtures) and `CollusionAdversary` (biased toward the honest centroid with jitter -- the actually interesting attack Multi-Krum's guarantee is about).
- `simulator.go` -- `Simulator.RunRound`/`Run`, calling the real, unmodified `internal.MultiKrumSelect` per committee per round. Committee membership is resampled every round from a seeded `math/rand/v2.PCG` source (deterministic given a seed); per-committee `f` is derived from `hva.MaximumByzantineNodes`, the same 5/9-derived constant everything else in this repo uses. `NewSimulator` validates the chosen topology actually satisfies `MultiKrumSelect`'s real `n > 2f+2` precondition up front rather than surfacing it as an opaque mid-run error.

No tracing yet (PR 2), no Lean (PR 3), no CI wiring (PR 4) -- pure Go simulator, independently reviewable.

## Test plan
- [x] `go build ./...`, `go vet ./internal/...`, `gofmt -l` all clean
- [x] `TestSimulator_RunRound_CallsRealMultiKrumSelect` -- confirms real `MultiKrumSelect` calls correctly exclude labeled-Byzantine far-outliers from every committee's selection (not a stub)
- [x] `TestSimulator_CommitteeMembershipResamplesEachRound` -- confirms committee membership genuinely differs round to round
- [x] `TestSimulator_DeterministicGivenSeed` -- two identically-seeded runs produce byte-identical bookkeeping across 3 rounds
- [x] `TestSimulator_CollusionAdversary` -- the more interesting attack path runs end to end
- [x] `TestNewSimulator_RejectsUnsafeTopology` -- precondition validation catches a bad topology at construction, not mid-run