### PR TITLE
feat(formal-verification): hierarchical BFT trace emission

### DIFF
--- a/internal/hbft/simulator.go
+++ b/internal/hbft/simulator.go
@@ -16,7 +16,9 @@ package hbft
 
 import (
 	"fmt"
+	"io"
 	"math/rand/v2"
+	"sync/atomic"
 
 	"github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/internal"
 	"github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/internal/hva"
@@ -84,6 +86,13 @@ type Simulator struct {
 	nodes     map[NodeID]*NodeState
 	tierPools [][]NodeID // per-tier node pool, resampled into committees each round
 	round     int
+
+	// TraceSink, when non-nil, receives one JSONL TraceEvent line per
+	// round_start/committee_formed/committee_selection/tier_aggregate/
+	// round_summary -- see trace.go. Nil by default: strictly opt-in,
+	// zero behavior change and zero overhead when untraced.
+	TraceSink io.Writer
+	traceSeq  atomic.Int64
 }
 
 // NewSimulator builds a Simulator and plants each tier's node population
@@ -145,6 +154,14 @@ func (s *Simulator) RunRound() (RoundResult, error) {
 	rng := rand.New(rand.NewPCG(s.cfg.Seed, uint64(s.round)))
 
 	result := RoundResult{Round: s.round, Seed: s.cfg.Seed}
+	if s.TraceSink != nil {
+		s.writeTrace(TraceEvent{
+			Event: "round_start",
+			Seq:   s.traceSeq.Add(1),
+			Round: s.round,
+			Seed:  s.cfg.Seed,
+		})
+	}
 	allSafe := true
 
 	for t := 0; t < s.cfg.Topology.Tiers; t++ {
@@ -170,15 +187,37 @@ func (s *Simulator) RunRound() (RoundResult, error) {
 		if 2*tierResult.SafeLeafWeight <= tierResult.TotalLeaves {
 			allSafe = false
 		}
+		if s.TraceSink != nil {
+			s.writeTrace(TraceEvent{
+				Event:           "tier_aggregate",
+				Seq:             s.traceSeq.Add(1),
+				Round:           s.round,
+				TierID:          t,
+				TotalLeaves:     tierResult.TotalLeaves,
+				ByzantineLeaves: tierResult.ByzantineLeaves,
+				SafeLeafWeight:  tierResult.SafeLeafWeight,
+			})
+		}
 		result.Tiers = append(result.Tiers, tierResult)
 	}
 	result.RootSafe = allSafe
+	if s.TraceSink != nil {
+		rootSafe := allSafe
+		s.writeTrace(TraceEvent{
+			Event:    "round_summary",
+			Seq:      s.traceSeq.Add(1),
+			Round:    s.round,
+			RootSafe: &rootSafe,
+		})
+	}
 
 	s.round++
 	return result, nil
 }
 
 func (s *Simulator) runCommittee(rng *rand.Rand, tierID, committeeIdx int, members []NodeID) (CommitteeResult, error) {
+	committeeID := fmt.Sprintf("t%d-c%d", tierID, committeeIdx)
+
 	labels := make([]bool, len(members))
 	var honestIdx, byzIdx []int
 	for i, id := range members {
@@ -188,6 +227,22 @@ func (s *Simulator) runCommittee(rng *rand.Rand, tierID, committeeIdx int, membe
 		} else {
 			honestIdx = append(honestIdx, i)
 		}
+	}
+
+	if s.TraceSink != nil {
+		memberIDs := make([]uint64, len(members))
+		for i, id := range members {
+			memberIDs[i] = uint64(id)
+		}
+		s.writeTrace(TraceEvent{
+			Event:        "committee_formed",
+			Seq:          s.traceSeq.Add(1),
+			Round:        s.round,
+			CommitteeID:  committeeID,
+			TierID:       tierID,
+			Members:      memberIDs,
+			MemberLabels: append([]bool(nil), labels...),
+		})
 	}
 
 	gradients := make([][]float64, len(members))
@@ -216,9 +271,24 @@ func (s *Simulator) runCommittee(rng *rand.Rand, tierID, committeeIdx int, membe
 	byzCount := countTrue(labels)
 	locallySafe := 2*(len(members)-byzCount) > len(members)
 
+	if s.TraceSink != nil {
+		safe := locallySafe
+		s.writeTrace(TraceEvent{
+			Event:       "committee_selection",
+			Seq:         s.traceSeq.Add(1),
+			Round:       s.round,
+			CommitteeID: committeeID,
+			TierID:      tierID,
+			ByzantineF:  f,
+			Gradients:   gradients,
+			SelectedIdx: append([]int(nil), selected...),
+			LocallySafe: &safe,
+		})
+	}
+
 	return CommitteeResult{
 		Committee: Committee{
-			ID:      fmt.Sprintf("t%d-c%d", tierID, committeeIdx),
+			ID:      committeeID,
 			TierID:  tierID,
 			Members: append([]NodeID(nil), members...),
 		},

--- a/internal/hbft/trace.go
+++ b/internal/hbft/trace.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Sovereign-Mohawk Core Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hbft
+
+import "encoding/json"
+
+// TraceEvent is one line of a JSONL execution trace of a Simulator run,
+// emitted when Simulator.TraceSink is set. See
+// proofs/TraceValidator/HierarchicalBFT.lean (added in a later PR) for the
+// Lean-side consumer that replays these events through a model reusing
+// proofs/LeanFormalization/Theorem1BFT.lean's HTree.safe weighted-credit
+// rule and independently re-runs Multi-Krum selection on the recorded
+// Gradients, cross-checking against SelectedIdx.
+//
+// MemberLabels is ground truth planted by the simulator (see node.go) --
+// internal.MultiKrumSelect never sees it, only Gradients. It exists in
+// the trace purely as the verification-only ground truth a structural
+// replay needs, exactly the way the RDP accountant's trace exposed
+// TotalEpsilon in full even though a production caller might not always
+// read it back. It is only ever present when TraceSink is explicitly set
+// (never in a production path, since nothing in this repo's production
+// code sets it).
+// Numeric fields shared across multiple event types (TierID, ByzantineF,
+// TotalLeaves, ByzantineLeaves, SafeLeafWeight) are deliberately NOT
+// `omitempty`: Go's encoding/json omits a struct field under `omitempty`
+// whenever it equals that type's zero value, and 0 is a real, legitimate
+// value for every one of these fields (tier 0 is a real tier; a fully
+// honest committee has ByzantineF-relevant counts of 0). Omitting them
+// would make "field is genuinely 0" indistinguishable from "field does
+// not apply to this event type" on the Lean-side parser -- caught during
+// this PR's own testing (tier 0's committee_formed/committee_selection
+// events were silently missing tier_id entirely). Booleans use the same
+// *bool-pointer fix already applied (LocallySafe, RootSafe): `false` is
+// equally a real value `omitempty` would otherwise conflate with absence.
+type TraceEvent struct {
+	Event string `json:"event"` // round_start|committee_formed|committee_selection|tier_aggregate|round_summary
+	Seq   int64  `json:"seq"`
+	Round int    `json:"round"`
+
+	Seed uint64 `json:"seed,omitempty"` // round_start only
+
+	CommitteeID string `json:"committee_id,omitempty"` // committee_formed, committee_selection; empty string never a real committee ID
+	TierID      int    `json:"tier_id"`                // committee_formed, committee_selection, tier_aggregate
+
+	Members      []uint64 `json:"members,omitempty"`       // committee_formed only
+	MemberLabels []bool   `json:"member_labels,omitempty"` // committee_formed only; ground truth, see doc comment above
+
+	ByzantineF  int         `json:"byzantine_f"`            // committee_selection only
+	Gradients   [][]float64 `json:"gradients,omitempty"`    // committee_selection only
+	SelectedIdx []int       `json:"selected_idx,omitempty"` // committee_selection only
+	LocallySafe *bool       `json:"locally_safe,omitempty"` // committee_selection only
+
+	// tier_aggregate only: this round's totals for TierID after folding
+	// in all of that tier's committees this round (not accumulated
+	// across rounds -- each round's tier_aggregate is a fresh count).
+	TotalLeaves     int `json:"total_leaves"`
+	ByzantineLeaves int `json:"byzantine_leaves"`
+	SafeLeafWeight  int `json:"safe_leaf_weight"`
+
+	RootSafe *bool `json:"root_safe,omitempty"` // round_summary only
+}
+
+// writeTrace best-effort emits ev as one JSON line to s.TraceSink. Tracing
+// must never be able to break simulator behavior: a nil sink is a no-op,
+// and marshal/write failures are swallowed rather than propagated.
+func (s *Simulator) writeTrace(ev TraceEvent) {
+	if s.TraceSink == nil {
+		return
+	}
+	line, err := json.Marshal(ev)
+	if err != nil {
+		return
+	}
+	line = append(line, '\n')
+	_, _ = s.TraceSink.Write(line)
+}

--- a/internal/hbft/trace_test.go
+++ b/internal/hbft/trace_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Sovereign-Mohawk Core Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hbft
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func newTracedSimulator(t *testing.T) (*Simulator, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	sim, err := NewSimulator(SimulatorConfig{
+		Topology:      TopologyConfig{Tiers: 2, CommitteesPerTier: 3, NodesPerCommittee: 27},
+		ByzantineRate: 0.2,
+		Adversary:     OutlierAdversary{Magnitude: 100},
+		Dimension:     3,
+		Seed:          5,
+	})
+	if err != nil {
+		t.Fatalf("NewSimulator failed: %v", err)
+	}
+	sim.TraceSink = &buf
+	return sim, &buf
+}
+
+func TestSimulator_NilTraceSinkEmitsNothing(t *testing.T) {
+	sim, err := NewSimulator(SimulatorConfig{
+		Topology:      testTopology(),
+		ByzantineRate: 0.2,
+		Adversary:     OutlierAdversary{Magnitude: 100},
+		Dimension:     4,
+		Seed:          1,
+	})
+	if err != nil {
+		t.Fatalf("NewSimulator failed: %v", err)
+	}
+	// TraceSink left nil (default).
+	if _, err := sim.RunRound(); err != nil {
+		t.Fatalf("RunRound failed: %v", err)
+	}
+	// Nothing to assert on output directly since there's no sink -- the
+	// real assertion is that RunRound didn't panic/error with a nil sink,
+	// confirming writeTrace's nil-check is exercised on the hot path.
+}
+
+func TestSimulator_TraceEventShapeAndOrder(t *testing.T) {
+	sim, buf := newTracedSimulator(t)
+	if _, err := sim.RunRound(); err != nil {
+		t.Fatalf("RunRound failed: %v", err)
+	}
+
+	events := parseTraceEvents(t, buf.Bytes())
+	if len(events) == 0 {
+		t.Fatal("expected at least one traced event")
+	}
+
+	if events[0].Event != "round_start" {
+		t.Fatalf("expected first event to be round_start, got %s", events[0].Event)
+	}
+	last := events[len(events)-1]
+	if last.Event != "round_summary" || last.RootSafe == nil {
+		t.Fatalf("expected last event to be a round_summary with RootSafe set, got %+v", last)
+	}
+
+	// Every committee_formed must be immediately followed by a
+	// committee_selection for the same committee, and every tier's block
+	// of committees must end with exactly one tier_aggregate for that
+	// tier before the next tier (or round_summary) begins.
+	seenTiers := map[int]bool{}
+	for i := 0; i < len(events); i++ {
+		ev := events[i]
+		switch ev.Event {
+		case "committee_formed":
+			if i+1 >= len(events) || events[i+1].Event != "committee_selection" {
+				t.Fatalf("committee_formed at seq %d not immediately followed by committee_selection", ev.Seq)
+			}
+			if events[i+1].CommitteeID != ev.CommitteeID {
+				t.Fatalf("committee_formed/committee_selection committee_id mismatch: %s vs %s", ev.CommitteeID, events[i+1].CommitteeID)
+			}
+			if len(ev.MemberLabels) != 27 {
+				t.Fatalf("committee_formed: expected 27 member_labels, got %d", len(ev.MemberLabels))
+			}
+		case "committee_selection":
+			if len(ev.Gradients) != 27 {
+				t.Fatalf("committee_selection: expected 27 gradients, got %d", len(ev.Gradients))
+			}
+			if ev.LocallySafe == nil {
+				t.Fatalf("committee_selection at seq %d missing locally_safe", ev.Seq)
+			}
+		case "tier_aggregate":
+			if seenTiers[ev.TierID] {
+				t.Fatalf("tier_aggregate for tier %d emitted more than once this round", ev.TierID)
+			}
+			seenTiers[ev.TierID] = true
+			if ev.TotalLeaves != 3*27 {
+				t.Fatalf("tier %d: expected total_leaves=%d, got %d", ev.TierID, 3*27, ev.TotalLeaves)
+			}
+		}
+	}
+	if len(seenTiers) != 2 {
+		t.Fatalf("expected tier_aggregate for both of the 2 configured tiers, got %d", len(seenTiers))
+	}
+}
+
+func TestSimulator_TraceSeqStrictlyIncreasing(t *testing.T) {
+	sim, buf := newTracedSimulator(t)
+	if _, err := sim.Run(3); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	events := parseTraceEvents(t, buf.Bytes())
+	for i := 1; i < len(events); i++ {
+		if events[i].Seq <= events[i-1].Seq {
+			t.Fatalf("trace seq not strictly increasing at index %d: %d then %d", i, events[i-1].Seq, events[i].Seq)
+		}
+	}
+}
+
+func parseTraceEvents(t *testing.T, data []byte) []TraceEvent {
+	t.Helper()
+	var events []TraceEvent
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var ev TraceEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			t.Fatalf("failed to parse traced JSONL line %q: %v", line, err)
+		}
+		events = append(events, ev)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("failed scanning trace buffer: %v", err)
+	}
+	return events
+}

--- a/test/hbft_trace_test.go
+++ b/test/hbft_trace_test.go
@@ -1,0 +1,134 @@
+package test
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/internal/hbft"
+)
+
+// TestHBFTTrace drives a realistic multi-tier, multi-round hierarchical
+// Multi-Krum execution with tracing enabled and writes the resulting
+// JSONL trace to test-results/hbft-trace/trace.jsonl. That file is the
+// input to the Lean trace validator
+// (proofs/TraceValidator/HierarchicalBFT.lean, added in a later PR),
+// which replays every committee_selection event by independently
+// re-running Multi-Krum selection on the recorded Gradients and
+// cross-checking against SelectedIdx, and folds committee outcomes into
+// per-tier weighted-safety bookkeeping mirroring
+// proofs/LeanFormalization/Theorem1BFT.lean's HTree.safe credited-weight
+// rule -- extending row 12's four fixed vectors to every committee-round
+// in a live, dynamic trace.
+//
+// Scale: 3 tiers, 4 committees per tier, 27 nodes per committee (the
+// smallest size comfortably satisfying MultiKrumSelect's n > 2f+2
+// precondition at the hva-derived f=12), 6 rounds -- deliberately small
+// for CI feasibility (MultiKrumSelect is O(n^2) per committee); see the
+// implementation plan's "Scale" section for why the actual 10M-node/
+// 50,000-per-committee deployment scale isn't CI-feasible.
+//
+// The scenario uses a CollusionAdversary (Byzantine members biased toward
+// the honest centroid, not a trivial far-outlier) so the trace exercises
+// the actually interesting case Multi-Krum's guarantee is about, not a
+// strawman.
+func TestHBFTTrace(t *testing.T) {
+	var buf bytes.Buffer
+	sim, err := hbft.NewSimulator(hbft.SimulatorConfig{
+		Topology:      hbft.TopologyConfig{Tiers: 3, CommitteesPerTier: 4, NodesPerCommittee: 27},
+		ByzantineRate: 0.2,
+		Adversary:     hbft.CollusionAdversary{Bias: 3.0},
+		Dimension:     4,
+		Seed:          20260807,
+	})
+	if err != nil {
+		t.Fatalf("NewSimulator failed: %v", err)
+	}
+	sim.TraceSink = &buf
+
+	results, err := sim.Run(6)
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	if len(results) != 6 {
+		t.Fatalf("expected 6 round results, got %d", len(results))
+	}
+
+	events := parseHBFTTraceLines(t, buf.Bytes())
+	if len(events) == 0 {
+		t.Fatal("expected at least one traced event, got none")
+	}
+
+	roundStarts, committeeFormed, committeeSelections, tierAggregates, roundSummaries := 0, 0, 0, 0, 0
+	for _, ev := range events {
+		switch ev.Event {
+		case "round_start":
+			roundStarts++
+		case "committee_formed":
+			committeeFormed++
+		case "committee_selection":
+			committeeSelections++
+		case "tier_aggregate":
+			tierAggregates++
+		case "round_summary":
+			roundSummaries++
+		default:
+			t.Fatalf("unexpected event type: %s", ev.Event)
+		}
+	}
+	if roundStarts != 6 || roundSummaries != 6 {
+		t.Fatalf("expected 6 round_start and 6 round_summary events, got %d and %d", roundStarts, roundSummaries)
+	}
+	wantPerRound := 3 * 4 // tiers * committeesPerTier
+	if committeeFormed != 6*wantPerRound || committeeSelections != 6*wantPerRound {
+		t.Fatalf("expected %d committee_formed and committee_selection events, got %d and %d",
+			6*wantPerRound, committeeFormed, committeeSelections)
+	}
+	if tierAggregates != 6*3 {
+		t.Fatalf("expected %d tier_aggregate events (6 rounds * 3 tiers), got %d", 6*3, tierAggregates)
+	}
+
+	writeHBFTTraceArtifact(t, buf.Bytes())
+}
+
+func parseHBFTTraceLines(t *testing.T, data []byte) []hbft.TraceEvent {
+	t.Helper()
+	var events []hbft.TraceEvent
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var ev hbft.TraceEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			t.Fatalf("failed to parse traced JSONL line %q: %v", line, err)
+		}
+		events = append(events, ev)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("failed scanning trace buffer: %v", err)
+	}
+	return events
+}
+
+// writeHBFTTraceArtifact writes the raw trace to
+// <repo-root>/test-results/hbft-trace/trace.jsonl, following the same
+// convention test/rdp_accountant_trace_test.go's writeTraceArtifact
+// established (Go test binaries run with cwd set to the package's source
+// directory, so ".." resolves to the repo root).
+func writeHBFTTraceArtifact(t *testing.T, data []byte) {
+	t.Helper()
+	outDir := filepath.Join("..", "test-results", "hbft-trace")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatalf("failed to create trace output dir %s: %v", outDir, err)
+	}
+	outPath := filepath.Join(outDir, "trace.jsonl")
+	if err := os.WriteFile(outPath, data, 0o644); err != nil {
+		t.Fatalf("failed to write trace artifact %s: %v", outPath, err)
+	}
+}


### PR DESCRIPTION
## Summary
PR 2 of 6 for trace-based runtime verification of row 1's flagship hierarchical Multi-Krum claim. **Stacked on #155** (base branch set to `feat/hbft-simulator-core`) so the diff shown here is only this PR's own contribution -- retarget to `main` once #155 lands.

- New `internal/hbft/trace.go`: `TraceEvent` JSONL schema (`round_start`, `committee_formed`, `committee_selection`, `tier_aggregate`, `round_summary`), wired into `Simulator` via a `TraceSink io.Writer` field (nil by default -- strictly opt-in, zero behavior change and zero overhead when untraced, same pattern as `internal/rdp_accountant.go`'s `TraceSink`).
- **Real bug caught and fixed during this PR's own testing**: `TierID`/`ByzantineF`/`TotalLeaves`/`ByzantineLeaves`/`SafeLeafWeight` were originally `omitempty`, which `encoding/json` applies whenever a field equals its zero value -- but 0 is a real, legitimate value for every one of these (tier 0 is a real tier). Tier 0's `committee_formed`/`committee_selection` events were silently missing `tier_id` entirely, indistinguishable from a field that doesn't apply to that event type. Fixed by dropping `omitempty` from those fields (matching the `*bool`-pointer fix already used for `LocallySafe`/`RootSafe`, where `false` has the identical `omitempty` problem for booleans).
- New `test/hbft_trace_test.go` drives a real 3-tier, 4-committees-per-tier, 27-nodes-per-committee, 6-round scenario (27 is the smallest committee size comfortably satisfying `MultiKrumSelect`'s `n > 2f+2` precondition at the hva-derived f=12) with a `CollusionAdversary` (not the trivial far-outlier case), writing the trace to `test-results/hbft-trace/trace.jsonl` -- the input for the Lean validator landing in PR 3.

## Test plan
- [x] `go build ./...`, `go vet ./internal/... ./test/...`, `gofmt -l` all clean
- [x] `internal/hbft/trace_test.go` confirms event shape/ordering (`committee_formed` always immediately followed by its `committee_selection`, exactly one `tier_aggregate` per tier per round) and strictly-increasing sequence numbers
- [x] Manually inspected the regenerated trace after the `tier_id` fix: confirmed `tier_id` now present (as `0`) on tier-0 events, previously silently absent
- [x] `test/hbft_trace_test.go` passes: 174 events across 6 rounds, exact expected counts per event type