### PR TITLE
fix(branch-protection): two real bugs found by actually running the script

### DIFF
--- a/scripts/apply_branch_protection.sh
+++ b/scripts/apply_branch_protection.sh
@@ -28,7 +28,12 @@ BRANCH="${BRANCH:-main}"
 # (no admin enforcement, no required-review count currently configured) --
 # review those two independently before changing them here, since they are
 # repo review-policy decisions, not CI-verification gates like the rest of
-# this script.
+# this script. `required_pull_request_reviews` must be explicitly `null`,
+# not omitted: GitHub's PUT branch-protection endpoint rejects a request
+# that leaves this key out entirely ("required_pull_request_reviews"
+# wasn't supplied", HTTP 422) even though its GET response simply omits
+# the key when unconfigured -- GET's response shape is not a reliable
+# guide to what PUT requires; confirmed by hitting this for real.
 
 PAYLOAD=$(cat <<'JSON'
 {
@@ -52,6 +57,7 @@ PAYLOAD=$(cat <<'JSON'
     ]
   },
   "enforce_admins": false,
+  "required_pull_request_reviews": null,
   "restrictions": null,
   "allow_force_pushes": false,
   "allow_deletions": false,
@@ -64,10 +70,15 @@ JSON
 )
 
 echo "Applying branch protection for ${OWNER}/${REPO}:${BRANCH}"
+# No leading slash on the endpoint: under Git Bash on Windows, MSYS
+# rewrites an argument starting with "/" as a filesystem path (e.g.
+# "/repos/..." becomes "C:/Program Files/Git/repos/..."), breaking gh's
+# API call. gh accepts the endpoint with or without the leading slash;
+# omitting it avoids the rewrite on every shell, not just Windows.
 gh api \
   --method PUT \
   -H "Accept: application/vnd.github+json" \
-  "/repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" \
+  "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" \
   --input - <<<"${PAYLOAD}"
 
 echo "Branch protection updated successfully."


### PR DESCRIPTION
## Summary
Following up on the earlier resync (#149): that pass verified the script's payload matched live branch protection by diffing against \`GET .../protection\`'s response shape, but never actually **executed** the script. Doing that today (with your explicit go-ahead, since it's a live security-settings PUT) surfaced two real bugs GET-based diffing couldn't catch:

1. **Git Bash/Windows path mangling**: the \`gh api\` call used a leading-slash endpoint (\`"/repos/..."\`), which MSYS rewrites as a filesystem path on Windows, breaking the call outright with \`invalid API endpoint\`. Fixed by dropping the leading slash (works identically on every shell).
2. **PUT requires a field GET doesn't show**: GitHub's branch-protection PUT endpoint rejects the whole request (\`422\`, \`"required_pull_request_reviews" wasn't supplied\`) if that key is omitted -- even though GET simply leaves the key out when it's unconfigured. Fixed by explicitly including \`"required_pull_request_reviews": null\`.

## Verified
Ran the corrected script for real against live \`main\` branch protection. Confirmed via a careful field-by-field diff beforehand that the resulting state is unchanged from before running it -- genuinely a no-op in terms of final protection state, but the script could not have completed successfully at all before this fix, regardless.

## Test plan
- [x] Ran the script for real, confirmed success and unchanged resulting protection state
- [ ] CI (this is a docs/tooling-only change, no Lean/Go/matrix files touched)