### PR TITLE
docs(formal-verification): refresh matrix validation run, ignore trace-run scratch output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,13 @@ test_output.txt
 test_results.txt
 stress_test_output.log
 
+# Ephemeral local runs of the trace-verification workflows (hbft-trace-verification.yml,
+# rdp-trace-verification.yml, hbft-statistical-sanity.yml) -- these workflows only ever
+# upload this output as a CI artifact, never commit it back to the repo.
+test-results/hbft-trace/
+test-results/rdp-trace/
+test-results/hbft-statcheck/
+
 # Local scratch / browser profile cache
 tmp/
 

--- a/proofs/FORMAL_TRACEABILITY_MATRIX.md
+++ b/proofs/FORMAL_TRACEABILITY_MATRIX.md
@@ -141,15 +141,16 @@ same tree the claim itself lives in.
 
 ## Latest Validation Run
 
-- Date (UTC): 2026-08-04
-- Branch: `feat/rdp-adaptive-composition` (off `main`, then merged forward
-  onto `main` after PR #144's docs-only Groth16/q-SDH feasibility finding
-  landed first — that PR touched only row 5 and this same section, no
-  overlap with row 2's content; resolved as a straightforward merge, not a
-  real content conflict). Closes row 2's "adaptive composition ... out of
-  scope" gap for real, using the corrected uniform-bound formulation
-  rather than the expectation-based chain rule previously cited — see that
-  row's updated notes for the full reasoning)
+- Date (UTC): 2026-08-10
+- Branch: `docs/refresh-formal-traceability-matrix-validation-run` (off
+  `origin/main`). Housekeeping refresh only — no new theorems, no matrix
+  row content changes. Brings this section current with two changes that
+  landed after the 2026-08-04 run below but never updated it: [PR
+  #162](https://github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto/pull/162)
+  (row 12's `n>2f+2` precondition and general-`m` selection closure) and
+  commit `27b989af` (removal of the unclaimed, vacuous
+  `Specification/Byzantine.lean`, PR #163) — neither PR had refreshed this
+  section's counts at merge time.
 - Commands executed:
   - `cd proofs && lake build LeanFormalization Specification Refinement`
   - `python3 scripts/ci/lint_formal_proof_claims.py --repo-root .`
@@ -160,21 +161,46 @@ same tree the claim itself lives in.
   - `python3 scripts/ci/generate_formal_validation_report.py --repo-root . --check`
   - `python3 scripts/ci/check_markdown_links.py`
 - Results:
-  - Lean build: pass, 8340 jobs; **zero `sorry`s remain in
-    `proofs/LeanFormalization`** (unaffected — this run adds two new
-    theorems, closes no sorries, introduces none). Both new theorems
-    (`RenyiDivergence_sum_le_of_bound`, `RDP_adaptive_composition`) were
-    first validated standalone via `lake env lean` against a scratch file
-    before being applied to the real file, per this repo's established
-    workflow
-  - Vacuous/misleading-theorem lint: pass (`22` Lean files checked)
-  - Traceability validation: pass (`10` modules, `91` theorem symbols, `38`
-    runtime test refs) — the `+2` vs. the pre-#144 baseline is the two new
-    theorems added to row 2's list (PR #144 was docs-only and added none);
-    runtime-test-ref count unchanged (pure Lean-side work)
+  - Lean build: pass, 8339 jobs (one fewer than the prior run's 8340, from
+    `Byzantine.lean`'s removal); **zero `sorry`s remain in
+    `proofs/LeanFormalization`**
+  - Vacuous/misleading-theorem lint: pass (`21` Lean files checked, down
+    from `22` — `Byzantine.lean` no longer exists to check)
+  - Traceability validation: pass (`10` modules, `91` theorem symbols, `44`
+    runtime test refs) — the `+6` vs. the 2026-08-04 baseline (`38`) is
+    PR #162's new/promoted test references (`TestMultiKrumLeanCorrespondence_GeneralM`
+    plus the HBFT/RDP trace-validator test suite:
+    `TestSimulator_RunRound_CallsRealMultiKrumSelect`,
+    `TestRunStatCheck_EmpiricalRateRoughlyMatchesTheory`,
+    `TestHBFTStatisticalSanityCheck`, `TestHBFTTrace`,
+    `TestRDPAccountantTrace`); theorem symbol count unchanged (`91`) since
+    PR #162 added new Refinement-layer functions/proofs rather than new
+    `theorem_claims.json`-tracked symbols
   - Theorem/runtime consistency check: pass (`12` regex checks, unchanged)
-  - Refinement drift check (`scripts/check_refinement.py`): pass (checked
-    since `Refinement/RDPAccountant.lean` is a related module for this
-    claim; unaffected — no `Refinement/*.lean` or Go files touched)
-  - Formal validation report consistency: pass after regeneration
-  - Markdown link check: pass (129 files)
+  - Refinement drift check (`scripts/check_refinement.py`): pass, `0`
+    missing on both sides (7 Lean Refinement/Specification files, 4 Go
+    files checked)
+  - Formal validation report consistency: pass after regeneration — real
+    content changes this run: `runtime_reference_count` corrected from a
+    stale `38` to `44` (matching the traceability validation above), plus
+    updated input file hashes/Merkle root reflecting the matrix and go.mod
+    changes since 2026-08-04
+  - Markdown link check: pass (130 files, up from 129)
+
+### Prior run — 2026-08-04
+
+- Branch: `feat/rdp-adaptive-composition` (off `main`, then merged forward
+  onto `main` after PR #144's docs-only Groth16/q-SDH feasibility finding
+  landed first — that PR touched only row 5 and this same section, no
+  overlap with row 2's content; resolved as a straightforward merge, not a
+  real content conflict). Closes row 2's "adaptive composition ... out of
+  scope" gap for real, using the corrected uniform-bound formulation
+  rather than the expectation-based chain rule previously cited — see that
+  row's updated notes for the full reasoning)
+- Results: Lean build pass (8340 jobs, zero `sorry`s); vacuous-theorem lint
+  pass (22 files); traceability validation pass (10 modules, 91 theorem
+  symbols, 38 runtime test refs — the `+2` vs. the pre-#144 baseline was
+  the two new theorems added to row 2's list); theorem/runtime consistency
+  pass (12 regex checks); refinement drift check pass; formal validation
+  report regenerated and self-consistent; markdown link check pass (129
+  files).

--- a/results/proofs/formal_validation_report.json
+++ b/results/proofs/formal_validation_report.json
@@ -8,7 +8,7 @@
       "surrogate_verified_with_gaussian_axiom": 1
     }
   },
-  "input_merkle_root": "09a3b8467164ac11f9d23d479bcf0fb19f13a8150138a86cd6f638f70f5d683a",
+  "input_merkle_root": "cb03bbd681950fd13da0e6eaf082db63b0d97164c7bfea66924a78eb75a2e00e",
   "inputs": [
     {
       "path": "capabilities.json",
@@ -16,11 +16,11 @@
     },
     {
       "path": "go.mod",
-      "sha256": "e3964e7d58a99004d3aad4241647f5820ba5efaf765da72e30d30db466db875f"
+      "sha256": "54ed2b97893983808db612a0f04c3ccef8ffc9378d61830994337d4cafdff164"
     },
     {
       "path": "proofs/FORMAL_TRACEABILITY_MATRIX.md",
-      "sha256": "3ebb6b53a3adbbd637eadde60957260bdcc77ccf823dd9c59450b7137b371653"
+      "sha256": "fec97b5b258ae7d8ae8ce4bd2af49c29fead156963d00e906bb6571c376edd54"
     },
     {
       "path": "proofs/LeanFormalization.lean",
@@ -68,7 +68,7 @@
     },
     {
       "path": "proofs/lakefile.lean",
-      "sha256": "97ac6cee72ef402a6d4bb89edb715479469c298dbe26855bb12cfada30c8926b"
+      "sha256": "978fd5491833c03de95bc7cb3ea5a2d65c0344d0605ccecd56305c663be347bc"
     },
     {
       "path": "proofs/lean-toolchain",
@@ -322,10 +322,13 @@
   "traceability": {
     "claims_path": "proofs/theorem_claims.json",
     "matrix_path": "proofs/FORMAL_TRACEABILITY_MATRIX.md",
-    "runtime_reference_count": 38,
+    "runtime_reference_count": 44,
     "runtime_references": [
       "internal/aggregator_multikrum_test.go::TestProcessGradientBatchWithMultiKrum",
+      "internal/hbft/simulator_test.go::TestSimulator_RunRound_CallsRealMultiKrumSelect",
+      "internal/hbft/statcheck_test.go::TestRunStatCheck_EmpiricalRateRoughlyMatchesTheory",
       "internal/multikrum_lean_correspondence_test.go::TestMultiKrumLeanCorrespondence",
+      "internal/multikrum_lean_correspondence_test.go::TestMultiKrumLeanCorrespondence_GeneralM",
       "internal/multikrum_test.go::TestMultiKrumSelect",
       "internal/token/ledger_lean_correspondence_test.go::TestLedgerLeanCorrespondence",
       "internal/token/migration_signatures.go::verifyMigrationSignatureBundle",
@@ -335,6 +338,8 @@
       "sdk/python/tests/test_flower_strategy.py::test_strategy_forwarder_aggregates_updates",
       "test/convergence_test.go::TestConvergenceMonitor_IsConverging_Above",
       "test/convergence_test.go::TestConvergenceMonitor_IsConverging_Below",
+      "test/hbft_statistical_sanity_test.go::TestHBFTStatisticalSanityCheck",
+      "test/hbft_trace_test.go::TestHBFTTrace",
       "test/manifest_test.go::TestValidateCommunicationComplexity_Valid",
       "test/manifest_test.go::TestValidateCommunicationComplexity_Violated",
       "test/phase3b_theorems_test.go::TestChernoffBound_Basic",
@@ -350,6 +355,7 @@
       "test/rdp_accountant_lean_correspondence_test.go::TestRDPAccountantLeanCorrespondence",
       "test/rdp_accountant_test.go::TestRDPAccountant_CheckBudget_Exceeded",
       "test/rdp_accountant_test.go::TestRDPAccountant_InitialBudget",
+      "test/rdp_accountant_trace_test.go::TestRDPAccountantTrace",
       "test/straggler_test.go::TestStragglerMonitor_ValidateLiveness_Fail",
       "test/straggler_test.go::TestStragglerMonitor_ValidateLiveness_Pass",
       "test/transport_byte_size_test.go::TestTransportByteSizeConvention",


### PR DESCRIPTION
## Summary
- Refreshes `proofs/FORMAL_TRACEABILITY_MATRIX.md`'s "Latest Validation Run" section, stale since 2026-08-04 (predates PR #162's row 12 closure and PR #163's `Byzantine.lean` removal, neither of which updated it). Re-ran the full local verification suite and recorded real current counts: Lean build 8339 jobs (zero sorries), vacuous-theorem lint 21 files, traceability validation 10 modules/91 theorem symbols/44 runtime test refs (up from 38), refinement drift check clean, markdown link check 130 files. No matrix row content changed, no new theorems — housekeeping only. Old run preserved below the new one, not deleted.
- Deletes three untracked local directories (`test-results/hbft-trace/`, `test-results/rdp-trace/`, `test-results/hbft-statcheck/`) left over from the already-merged 2026-08-07 trace-verification session, and gitignores those paths — their producing workflows (`hbft-trace-verification.yml`, `rdp-trace-verification.yml`, `hbft-statistical-sanity.yml`) only ever upload this output as a CI artifact, never commit it.

## Test plan
- [x] `cd proofs && lake build LeanFormalization Specification Refinement` — pass, 8339 jobs
- [x] `python3 scripts/ci/lint_formal_proof_claims.py --repo-root .` — pass
- [x] `bash scripts/ci/validate_formal_traceability.sh` — pass
- [x] `python3 scripts/ci/check_theorem_runtime_consistency.py --repo-root .` — pass
- [x] `python3 scripts/check_refinement.py --lean proofs/Specification/System.lean --go internal/ --json` — pass, 0 missing both sides
- [x] `python3 scripts/ci/generate_formal_validation_report.py --repo-root .` then `--check` — pass
- [x] `python3 scripts/ci/check_markdown_links.py` — pass, 130 files
- [x] `python3 scripts/ci/check_claim_transitions.py` — pass, confirms no Status-cell changes (no `CLAIM_TRANSITIONS.md` entry needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)