### PR TITLE
docs(notice): state explicitly there is no proprietary/enterprise license tier

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -11,6 +11,10 @@ Portions of protocol technology implemented in this repository are marked **Pate
 
 This notice is informational and does not modify, replace, or restrict permissions granted by Apache-2.0 for this repository.
 
+## Licensing Model
+
+This repository has no separate proprietary or enterprise-tier license: all code here is Apache-2.0. There is no dual-license split and no gated "enterprise edition" — the Patent Pending disclosure above does not create one.
+
 ## Trademark and Naming
 
 Project names, marks, and branding are not granted for unrestricted use by the Apache-2.0 copyright license.


### PR DESCRIPTION
## Summary
- An external gap analysis of this repo claimed a "dual-license (core Apache 2.0 + proprietary enterprise pieces)" model, common on other FL platforms. Verified against `LICENSE.md`, `README.md`, `SECURITY.md`, `docs/WHITE_PAPER.md`, `CONTRIBUTING.md`, and `docs/DoD_Alignment_Addendum.md`: every IP-related mention in this repo is the same Patent Pending disclosure (US provisional, March 2026), and each instance explicitly states it does not alter Apache-2.0 terms. No second `LICENSE` file, no `enterprise/` directory, no commercial/BUSL/SSPL reference exists anywhere in the repo.
- Adds one explicit "Licensing Model" section to `NOTICE.md` stating there is no proprietary/enterprise tier, so this isn't left implicit for future audits.

## Test plan
- [x] `python3 scripts/ci/check_markdown_links.py` — pass, 130 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)