### PR TITLE
docs(getting-started): replace placeholder scaffold with real content, fix phantom make targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,8 @@ Latest TPM production closure evidence (2026-04-11):
 Generated artifacts are managed with retention + canonical-summary automation. Policy details are in [docs/ARTIFACT_GOVERNANCE.md](docs/ARTIFACT_GOVERNANCE.md).
 
 ```bash
-make artifact-retention-dryrun
-make artifact-retention-apply
+scripts/manage_artifacts.sh --keep 3 --archive
+scripts/manage_artifacts.sh --keep 3 --archive --apply
 make artifact-summary
 ```
 
@@ -266,7 +266,7 @@ INPUT_CSV=/path/to/export.csv ./scripts/run_synthesizebio_demo.sh
 For a Docker-native end-to-end run that starts the stack, trains, validates, and copies artifacts into the repo, use:
 
 ```bash
-DATASET=https://app.synthesize.bio/datasets/<dataset-id> make demo-synthesizebio-docker VALIDATION_PROFILE=fast
+DATASET=https://app.synthesize.bio/datasets/<dataset-id> VALIDATION_PROFILE=fast ./scripts/run_synthesizebio_demo_in_docker.sh
 ```
 
 ## Security Defaults (Current)
@@ -663,11 +663,20 @@ PowerShell stop:
 
 Windows GUI launcher:
 
-```bash
-make testnet-gui-windows
-```
+`make testnet-gui-windows` is not a real Makefile target as of this
+writing. `cmd/testnet-gui` (with a real `main_windows.go` build-tagged
+entry point) does exist in this repo and is functionally real — it opens
+a native Windows desktop window for the testnet stack, reuses
+`scripts/launch_full_stack_3_nodes.ps1`/`.sh` and `genesis-launch.sh` for
+start/stop, and exposes quick links to Grafana, Prometheus, and the
+orchestrator control plane (all confirmed directly in
+`cmd/testnet-gui/main.go`/`main_windows.go`) — but there is no verified
+build or packaging script here that produces `dist/windows/testnet-gui.exe`
+from it. Build it directly if you want to try it:
 
-That target builds `dist/windows/testnet-gui.exe`, which opens a native Windows desktop window for the testnet stack and reuses the checked-in Windows launcher script for start/stop actions. It also exposes quick links to Grafana, Prometheus, and the orchestrator control plane.
+```bash
+GOOS=windows GOARCH=amd64 go build -o dist/windows/testnet-gui.exe ./cmd/testnet-gui
+```
 
 Grafana dashboard shortlist:
 
@@ -774,19 +783,23 @@ go test ./test -run 'TestSwarmIntegration500To1000Nodes|TestByzantineEdgeCasesOv
 
 ### Python SDK Tests
 
+`test-python-sdk`, `demo-python-sdk`, and `python-all` are not real Makefile
+targets as of this writing. The real invocation, matching what CI's
+`build-test.yml` actually runs:
+
 ```bash
-make test-python-sdk
-make demo-python-sdk
-make python-all
+cd sdk/python
+python3 -m pip install -e .[dev]
+pytest -q --junitxml=../../test-results/python-sdk-junit.xml
 ```
 
 ### Production Readiness Check
 
-Run the full production readiness gate (lint + tests + audit + strict auth/role smoke on host and container):
-
-```bash
-make production-readiness
-```
+`make production-readiness` is not a real Makefile target as of this
+writing — there is no single command in this repo that runs lint + tests +
+audit + strict auth/role smoke together. The closest real, individually verified pieces: `make verify`
+(tests + audit), `make lint` / `make black` (Python lint/format checks),
+and the go-live gate validators below.
 
 ### Formal Go-Live Gate
 
@@ -932,7 +945,7 @@ Comparison artifact:
 FedAvg scaling controls and validation artifacts:
 
 * Semi-async, hierarchical, and weighted-trim aggregation controls are available through the aggregation API and test harness.
-* `make fedavg-scale-gate` validates throughput floors and pre/post counter deltas for the current runtime report.
+* `python3 scripts/validate_fedavg_scale_gates.py` validates throughput floors and pre/post counter deltas for the current runtime report (`make fedavg-scale-gate` is not a real Makefile target as of this writing — this is the real script it should have named).
 * `captured_artifacts/fedavg_10k_node_runtime_evaluation_2026-04-13.md` captures the 10k-node runtime smoke evaluation and improvement notes.
 
 CI baseline pinning behavior:
@@ -959,11 +972,10 @@ Published CI artifacts include:
 
 ### CPU vs GPU vs NPU Side-by-Side Benchmark
 
-Run the hardware-policy benchmark report (used by CI and release assets):
-
-```bash
-make benchmark-gpu
-```
+`make benchmark-gpu` is not a real Makefile target as of this writing, and
+no equivalent script was found in this repo. Treat this section's
+downstream artifact claims as unverified until a real generation path is
+added.
 
 Artifacts:
 
@@ -1020,7 +1032,7 @@ All production-grade safety requirements are verified on every push:
 
 * **Build and Test:** Go build/test, Wasm module build, capability validation, and Docker stack config. The PR build/test workflow keeps benchmark-heavy Python SDK suites in the dedicated performance gate.
 * **Integrity Guard - Linter:** `golangci-lint`, `black --check`, and targeted `flake8` validation.
-* **Local Toolchain Consistency:** Run `make go-env` before local Go lint/test commands to confirm `go` and `compile` resolve to the same toolchain root.
+* **Local Toolchain Consistency:** `source scripts/ensure_go_toolchain.sh` before local Go lint/test commands to confirm `go` and `compile` resolve to the same toolchain root (every real Go-related Makefile target already sources this internally).
 * **Performance Gate:** Benchmark regression checks for proof verification, aggregation, and gradient compression.
 * **Swarm Runtime Matrix:** 500/1000/1500-node safe+edge Byzantine runtime profiles with router-on preflight evidence and published artifacts.
 * **FedAvg Benchmark Compare:** Go runtime FedAvg benchmark matrix diff against base branch with markdown artifact upload.

--- a/README.md
+++ b/README.md
@@ -505,18 +505,12 @@ Validated startup options:
 
 # Start orchestrator + shard + node-agent-1..3
 ./scripts/genesis-launch.sh --all-nodes
-
-# Equivalent Make target
-make regional-shard
 ```
 
 1. Full local stack (orchestrator + 3 node agents):
 
 ```bash
 ./scripts/launch_full_stack_3_nodes.sh --no-build
-
-# Equivalent Make target
-make full-stack-3-nodes
 ```
 
 Native PowerShell (Windows):
@@ -659,9 +653,6 @@ Stop the stack:
 
 ```bash
 ./scripts/launch_full_stack_3_nodes.sh --down
-
-# Equivalent Make target
-make full-stack-3-nodes-down
 ```
 
 PowerShell stop:

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -7,7 +7,7 @@
 
 ## Quick Navigation
 
-- **[Getting Started](guides/GETTING_STARTED.md)** - Installation, quickstart, first steps (placeholder stub — see [Documentation Status](#documentation-status))
+- **[Getting Started](guides/GETTING_STARTED.md)** - Installation, quickstart, first steps (real)
 - **[Architecture Guide](ARCHITECTURE.md)** - System design, component overview
 - **[API Reference](API_REFERENCE.md)** - Go packages, gRPC services, Python SDK
 - **[Deployment Guide](DEPLOYMENT.md)** - Docker, Kubernetes, Cloud deployment
@@ -69,7 +69,7 @@ docs/architecture/
 ```
 docs/guides/
 ├── README.md                        - (real) directory overview
-├── GETTING_STARTED.md               - Installation, quickstart
+├── GETTING_STARTED.md               - (real) Installation, quickstart
 ├── DEPLOYMENT.md                    - Docker, K8s, Cloud templates
 ├── OPERATIONS.md                    - Monitoring, troubleshooting
 ├── MONITORING_OBSERVABILITY.md      - Prometheus, Grafana, Jaeger
@@ -243,6 +243,7 @@ What's actually real and worth trusting:
 - Formal proofs and specifications: real, see [proofs/FORMAL_TRACEABILITY_MATRIX.md](../proofs/FORMAL_TRACEABILITY_MATRIX.md) for the honest per-theorem scope.
 - The Genesis Testnet deployment path in the root [README.md](../README.md) (Docker Compose, launch scripts) — actually runnable.
 - `sdk/python/README.md` for the Python SDK API surface.
+- [guides/GETTING_STARTED.md](guides/GETTING_STARTED.md) — real content as of this update, every command verified against actual scripts/Makefile targets/Compose files in this repo.
 
 Treat any other doc under `docs/` not listed above as unverified until you've
 checked it against the actual code -- this index's own file inventory has

--- a/docs/SYNTHESIZE_BIO_DEMO_PLAN.md
+++ b/docs/SYNTHESIZE_BIO_DEMO_PLAN.md
@@ -143,7 +143,7 @@ Exit criteria:
 ## Demo Command Path (Target)
 ```bash
 # 1) bootstrap stack
-make full-stack-3-nodes
+./scripts/launch_full_stack_3_nodes.sh --no-build
 
 # 2) run synthesize.bio demo scenario
 bash scripts/run_synthesizebio_demo.sh

--- a/docs/SYNTHESIZE_BIO_DEMO_PLAN.md
+++ b/docs/SYNTHESIZE_BIO_DEMO_PLAN.md
@@ -153,7 +153,7 @@ bash scripts/demo_synthesizebio_collect_metrics.sh
 make go-live-gate-advisory
 
 # 4) teardown
-make full-stack-3-nodes-down
+./scripts/launch_full_stack_3_nodes.sh --down
 ```
 
 ## Risks and Mitigations

--- a/docs/guides/GETTING_STARTED.md
+++ b/docs/guides/GETTING_STARTED.md
@@ -1,5 +1,188 @@
-# GETTING STARTED
+# Getting Started
 
-Scaffold document created to preserve canonical documentation links.
+This guide covers three real, runnable ways to get Sovereign-Mohawk running
+locally, from fastest/lightest to most complete. Everything below was
+verified against the actual scripts, Makefile targets, and Docker Compose
+files in this repository as of this writing — nothing here is aspirational.
+For what's still a placeholder elsewhere in the docs tree, see
+[docs/INDEX.md](../INDEX.md#documentation-status).
 
-See [docs/INDEX.md](../INDEX.md) for current navigation and status.
+## Prerequisites
+
+- **Go** — version pinned in [go.mod](../../go.mod) (`go 1.26.5` as of this
+  writing). Only needed if you're building the Go runtime or the Python
+  SDK's native library.
+- **A working C compiler, with `CGO_ENABLED=1`** — required specifically
+  for `make build-python-lib` in Path 1 below (it builds
+  `internal/pyapi/api.go`, which uses `import "C"`). On Linux/macOS a C
+  toolchain is normally already present and `CGO_ENABLED` defaults to `1`
+  automatically. **On Windows there is no C compiler by default** — without
+  one, `go build -buildmode=c-shared` silently excludes the cgo file from
+  the build and fails with the confusing error `go: no Go source files`
+  (this is a build-constraint exclusion, not a "file not found" — it
+  reproduces on a clean checkout with only the standard Go toolchain
+  installed). Install a MinGW-w64 toolchain (e.g. `choco install mingw`,
+  then confirm with `where gcc`) and ensure `go env CGO_ENABLED` reports
+  `1` before running Path 1. This prerequisite does not affect Paths 2/3 —
+  `cmd/node-agent/Dockerfile` builds the same `libmohawk.so` with
+  `CGO_ENABLED=1`, but inside the Docker build image, which already
+  includes its own C toolchain regardless of your host.
+- **Python** — 3.8+ (per [sdk/python/pyproject.toml](../../sdk/python/pyproject.toml)).
+  Only needed for the Python SDK path.
+- **Docker + Docker Compose v2** (the `docker compose` subcommand, not the
+  standalone `docker-compose` binary) — needed for the Genesis Testnet and
+  Sandbox paths below.
+- **git**
+
+No manual `.env` setup is required to start the stack: `scripts/genesis-launch.sh`
+auto-creates `.env` from [.env.example](../../.env.example) with a generated
+local Grafana admin password on first run if one doesn't already exist.
+
+## Path 1: Python SDK + Flower quickstart (fastest)
+
+This is the fastest way to see the runtime do something — no Docker
+required.
+
+```bash
+git clone https://github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto.git
+cd Sovereign-Mohawk-Proto
+make build-python-lib
+cd sdk/python
+pip install -e .[flower]
+python examples/flower_integrated/quickstart_pytorch.py --ci
+```
+
+`make build-python-lib` compiles `internal/pyapi/api.go` into a C-shared
+library (`libmohawk.so`) that the Python SDK loads via `ctypes` — this step
+is why Go is a prerequisite even for the Python-only path.
+
+This gives you a Flower-compatible client flow using Mohawk's security
+primitives end-to-end locally. The `--ci` flag runs it as a smoke test; drop
+it and set `submit_updates=True` on your `MohawkFlowerClient` for a live run
+that actually submits updates to aggregation. See
+[sdk/python/README.md](../../sdk/python/README.md) for the full API surface.
+
+Prefer installing from PyPI instead of building from source:
+
+```bash
+pip install mohawk[flower]
+```
+
+**Larger local simulation** (1024 virtual nodes, no Docker):
+
+```bash
+make simulate-fl-1k
+```
+
+## Path 2: Genesis Testnet (multi-node Docker stack)
+
+This is the real, runnable multi-node path — orchestrator, sharding,
+node agents, Multi-Krum Byzantine filtering, Prometheus/Grafana monitoring,
+IPFS.
+
+```bash
+git clone https://github.com/rwilliamspbg-ops/Sovereign-Mohawk-Proto.git
+cd Sovereign-Mohawk-Proto
+
+# Regional profile: orchestrator + shard + node-agent-1
+./scripts/genesis-launch.sh
+
+# Or the full local 3-node stack: orchestrator + shard + node-agent-1..3
+./scripts/launch_full_stack_3_nodes.sh --no-build
+```
+
+On Windows, use native PowerShell instead:
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+./scripts/launch_full_stack_3_nodes.ps1 -NoBuild
+```
+
+Check it's running:
+
+```bash
+docker compose ps
+```
+
+Default endpoints once up:
+
+- Grafana: `http://localhost:3000` (login: `admin` / see `GRAFANA_ADMIN_PASSWORD` in `.env`)
+- Prometheus: `http://localhost:9090`
+- TPM metrics exporter: `http://localhost:9102/metrics`
+- Orchestrator control plane: `https://localhost:8080` (mTLS enforced)
+
+Add more node agents after startup:
+
+```bash
+./scripts/docker-compose-wrapper.sh up -d node-agent-2 node-agent-3
+```
+
+**Windows/Git Bash note:** always call the wrapper with its `./scripts/`
+path (`./scripts/docker-compose-wrapper.sh ...`). Running
+`docker-compose-wrapper.sh ...` without the path fails with
+`command not found`.
+
+Stop the stack:
+
+```bash
+docker compose down
+```
+
+To scale a single `node-agent` service with replicas instead of named
+services, use `docker-compose.full.yml` directly; if you need per-replica
+mTLS identities, make sure the cert pool is at least as large as the
+replica count:
+
+```bash
+MOHAWK_TPM_CLIENT_CERT_POOL_SIZE=10 docker compose -f docker-compose.full.yml up -d --scale node-agent=10
+```
+
+## Path 3: Sandbox (lightest Docker on-ramp)
+
+A smaller topology (1 orchestrator, 1 shard, 2 node agents, a bundled
+"Hello World" FL WASM task) for quick research/dev iteration:
+
+```bash
+docker compose -f docker-compose.sandbox.yml up -d --build
+
+# equivalent:
+./scripts/launch_sandbox.sh
+make sandbox-up
+```
+
+Check it:
+
+```bash
+docker compose -f docker-compose.sandbox.yml ps
+docker logs --tail=100 node-agent-1
+docker logs --tail=100 node-agent-2
+```
+
+Stop it:
+
+```bash
+docker compose -f docker-compose.sandbox.yml down
+```
+
+## What's not covered here
+
+- **Kubernetes/cloud deployment** — `docs/guides/DEPLOYMENT.md` and the
+  `docs/guides/KUBERNETES_DEPLOYMENT.md` / `CLOUD_DEPLOYMENT.md` paths
+  linked from [docs/INDEX.md](../INDEX.md) are still placeholder scaffolds
+  as of this writing. `deploy/cloud-templates/README.md` and
+  `./scripts/helm-install.sh` / `make deploy-to-kind` exist in this repo,
+  but are not walked through step-by-step anywhere yet.
+- **Performance numbers** — don't trust any throughput/latency figure you
+  see elsewhere in the docs as a guarantee; see
+  [PERFORMANCE.md](../../PERFORMANCE.md) for how to measure your own.
+- **Production/Phase 4 deployment claims** — see
+  [docs/PHASE_4_PRODUCTION_DEPLOYMENT.md](../PHASE_4_PRODUCTION_DEPLOYMENT.md)
+  for what's real versus what was previously fabricated in that area.
+
+## Where to go next
+
+- Full documentation navigation: [docs/INDEX.md](../INDEX.md)
+- Formal verification status (start here for any resilience/privacy claim):
+  [proofs/FORMAL_TRACEABILITY_MATRIX.md](../../proofs/FORMAL_TRACEABILITY_MATRIX.md)
+- Python SDK full API reference: [sdk/python/README.md](../../sdk/python/README.md)
+- Benchmarks and reproducibility: [docs/BENCHMARKS_AND_REPRODUCIBILITY.md](../BENCHMARKS_AND_REPRODUCIBILITY.md)


### PR DESCRIPTION
## Summary
- Replaces `docs/guides/GETTING_STARTED.md`'s 5-line placeholder scaffold (per `docs/INDEX.md`'s own audit) with three real, runnable paths: Python SDK + Flower quickstart, Genesis Testnet multi-node Docker stack, and the lightweight sandbox. Every command was cross-checked against actual scripts/Makefile targets/Compose files rather than copied from README without verification.
- Live-tested `make build-python-lib` (Path 1's first command) and hit a real, previously-undocumented gap: it needs `CGO_ENABLED=1` and a C compiler, absent by default on Windows — without one the build silently excludes the cgo-dependent `internal/pyapi/api.go` and fails with the confusing `go: no Go source files`, not an obviously CGO-related error. Root-caused via `go env CGO_ENABLED`/`which gcc`, confirmed `cmd/node-agent/Dockerfile` builds the same file with `CGO_ENABLED=1` inside Docker's own C toolchain (so Paths 2/3 are unaffected), and documented this precisely in Prerequisites.
- Updates `docs/INDEX.md` to mark `GETTING_STARTED.md` as `(real)` in three places instead of "placeholder stub".
- **Systematic phantom-Makefile-target audit** (grew from an initial spot-check of 3 into a full diff of every `make <target>` reference in `README.md`/`docs/SYNTHESIZE_BIO_DEMO_PLAN.md` against the real Makefile): found and fixed **13 total** references to Make targets that don't exist. 8 got a verified real replacement (`artifact-retention-dryrun/apply` → `scripts/manage_artifacts.sh --keep 3 --archive [--apply]`; `go-env` → `source scripts/ensure_go_toolchain.sh`; `test-python-sdk`/`demo-python-sdk`/`python-all` → the real pytest invocation from CI; `demo-synthesizebio-docker` → `scripts/run_synthesizebio_demo_in_docker.sh`; `fedavg-scale-gate` → `python3 scripts/validate_fedavg_scale_gates.py`; `regional-shard`/`full-stack-3-nodes`/`full-stack-3-nodes-down` → the real launch scripts). 3 had no verified replacement (`production-readiness`, `benchmark-gpu`, `testnet-gui-windows`) and are now disclosed honestly instead of left as broken instructions — for `testnet-gui-windows` specifically, confirmed `cmd/testnet-gui` itself is real and functionally accurate as documented by actually cross-compiling it (`GOOS=windows GOARCH=amd64 go build -o dist/windows/testnet-gui.exe ./cmd/testnet-gui`, which succeeds — pure syscall-based Win32 bindings, no cgo needed).

## Test plan
- [x] `python3 scripts/ci/check_markdown_links.py` — pass, 130 files (run after each commit)
- [x] Live-ran `make build-python-lib` locally, hit and diagnosed the real CGO/Windows failure documented above
- [x] Confirmed every script/Compose file/Make target referenced in the new guide exists (`genesis-launch.sh`, `launch_full_stack_3_nodes.sh`/`.ps1`, `docker-compose-wrapper.sh`, `launch_sandbox.sh`, `docker-compose.full.yml`, `docker-compose.sandbox.yml`, `make simulate-fl-1k`, `make sandbox-up`)
- [x] Confirmed the `flower` extra in `sdk/python/pyproject.toml` and `quickstart_pytorch.py` both exist
- [x] Systematic diff: extracted every `make <target>` reference from the two edited files, compared against every real Makefile target, verified zero remaining phantom references (only appear now inside honest-disclosure prose, not as runnable commands)
- [x] Actually cross-compiled `cmd/testnet-gui` for Windows and confirmed the binary is produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)