### PR TITLE
perf(kind): add local scale harness and capture 500/700 evidence boundary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 .PHONY: go-live-gate go-live-gate-strict go-live-gate-advisory golden-path-e2e failure-injection-latency-check
 .PHONY: tpm-attestation-closure-check tpm-closure-summary ga-tag-ready-check release-performance-evidence
 .PHONY: openapi-spec capability-dashboard-matrix mainnet-one-click local-validation-scripts
-.PHONY: simulate-fl-1k benchmarks-reproducibility deploy-to-kind cloud-template-scaffold
+.PHONY: simulate-fl-1k benchmarks-reproducibility deploy-to-kind cloud-template-scaffold run-kind-scale-test
 
 help:
 	@echo "Sovereign-Mohawk Development Commands"
@@ -46,6 +46,12 @@ help:
 	@echo "  make simulate-fl-1k  - Run zero-config local FL simulator (1k virtual nodes)"
 	@echo "  make benchmarks-reproducibility - Build reproducibility benchmark artifacts"
 	@echo "  make deploy-to-kind  - Deploy Helm chart to local kind cluster"
+	@echo "  make run-kind-scale-test - Run the stronger local kind scale-test harness"
+	@echo "  make run-kind-scale-matrix - Run staged local kind scale matrix (100/300/500)"
+	@echo "  make collect-kind-scale-latency - Capture kind scale latency evidence"
+	@echo "  make run-kind-scale-evidence - Run matrix + latency evidence together"
+	@echo "  make check-test-host-prereqs - Validate local host tools for kind-based evidence"
+	@echo "  make install-kind-prereqs-ubuntu - Install kind/kubectl/docker on Ubuntu/Debian"
 	@echo "  make cloud-template-scaffold - Show cloud quickstart scaffold assets"
 	@echo "  make lint            - Check code with linters (ruff)"
 	@echo "  make black           - Check code formatting (black)"
@@ -210,6 +216,28 @@ benchmarks-reproducibility:
 
 deploy-to-kind:
 	@bash scripts/deploy_to_kind.sh
+
+run-kind-scale-test:
+	@bash scripts/check_test_host_prereqs.sh
+	@bash scripts/run_kind_scale_test.sh
+
+run-kind-scale-matrix:
+	@bash scripts/check_test_host_prereqs.sh
+	@bash scripts/run_kind_scale_matrix.sh
+
+collect-kind-scale-latency:
+	@bash scripts/check_test_host_prereqs.sh
+	@bash scripts/collect_kind_scale_latency.sh
+
+run-kind-scale-evidence:
+	@bash scripts/check_test_host_prereqs.sh
+	@bash scripts/run_kind_scale_evidence.sh
+
+check-test-host-prereqs:
+	@bash scripts/check_test_host_prereqs.sh
+
+install-kind-prereqs-ubuntu:
+	@bash scripts/install_kind_prereqs_ubuntu.sh
 
 cloud-template-scaffold:
 	@echo "Cloud template scaffolds:"

--- a/deploy/kubernetes/scale-test/multi-host-readiness.md
+++ b/deploy/kubernetes/scale-test/multi-host-readiness.md
@@ -1,0 +1,52 @@
+# Multi-host readiness recipe
+
+This is the next-step recipe for moving beyond the single-host kind ceiling and establishing stronger distributed evidence.
+
+## Goal
+
+Validate real control/data-plane behavior across multiple hosts, not just a single laptop-run kind cluster.
+
+## Minimum environment
+
+- 2 to 3 commodity Linux hosts with Docker or containerd
+- network connectivity between hosts
+- shared access to the same image registry or image tarball distribution
+- a Kubernetes distro such as k3d, kubeadm, or managed control plane
+
+## Suggested topology
+
+- 1 control-plane node
+- 2 to 3 worker nodes
+- 1 or more orchestrator replicas
+- 1 IPFS/metadata service
+- 20, 100, 300, 500 worker replicas depending on host capacity
+
+## Production-like changes
+
+- do not run the entire fleet in one node
+- use separate hosts for control-plane and workload nodes
+- keep the `node-agent` replica count bounded by per-host resource headroom
+- keep the cert pool on a shared volume or per-node secret distribution path
+- record pod readiness, etcd/controller-plane health, and request latency together
+
+## Basic workflow
+
+1. Build the repository images locally or in CI.
+2. Push or distribute them to all hosts.
+3. Create a multi-node Kubernetes cluster.
+4. Deploy the orchestrator and metadata service.
+5. Deploy the node-agent StatefulSet with a pool of certs.
+6. Scale in stages: 20 -> 100 -> 300 -> 500.
+7. Capture logs, pod state, and latency deltas at each stage.
+
+## Evidence to collect
+
+- pod readiness by stage
+- mean and p95 submit latency
+- control-plane stability
+- mTLS validation and auth check results
+- any failure or restart events
+
+## Why this matters
+
+A single kind cluster on one laptop creates a disk I/O ceiling that is unrelated to the application logic. Multi-host deployment evidence would prove the control/data planes work across host boundaries, which is the missing evidence the repo currently calls out as a gap.

--- a/results/go-live/evidence/kind-scale-matrix/scale-evidence-2026-08-16.md
+++ b/results/go-live/evidence/kind-scale-matrix/scale-evidence-2026-08-16.md
@@ -1,0 +1,31 @@
+# Local kind scale evidence - 2026-08-16
+
+## Environment
+
+- Runtime: one-node kind cluster in the current codespace.
+- Node capacity and allocatable CPU: 4 cores.
+- Pod CIDR: `10.244.0.0/20`; kubelet maximum pods: 2000.
+- Node-agent resource request: 5m CPU and 16Mi memory.
+
+## Completed readiness tiers
+
+| Requested node-agent replicas | Ready replicas | Result | Evidence |
+| --- | --- | --- | --- |
+| 100 | 100 | Pass | `pods_100.txt`, `statefulset_100.yaml` |
+| 300 | 300 | Pass | `pods_300.txt`, `statefulset_300.yaml` |
+| 500 | 500 | Pass | `pods_500.txt`, `statefulset_500.yaml` |
+
+## 700-replica boundary
+
+The 700-replica run did not reach full readiness within the harness's 600-second rollout timeout. At diagnostic capture, 566 node-agent pods were running and 134 were pending. Kubernetes reported `FailedScheduling` for the pending pods because the sole kind node had insufficient CPU. No node-agent pods had restarted, so this is host scheduler capacity pressure rather than an application crash.
+
+Captured diagnostics:
+
+- `statefulset_700_timeout.yaml`
+- `pods_700_timeout.txt`
+- `pods_700_timeout.json`
+- `pending_700_timeout.txt`
+- `events_700_timeout.txt`
+- `node_700_timeout.txt`
+
+This validates 500 ready node-agent replicas as the largest completed real workload tier in this codespace. The 700-replica attempt establishes the next observed single-host limit; it is not evidence of a distributed or multi-host ceiling.

--- a/results/go-live/evidence/kind-scale-matrix/summary.csv
+++ b/results/go-live/evidence/kind-scale-matrix/summary.csv
@@ -1,0 +1,5 @@
+requested_replicas,ready_replicas,result
+100,100,pass
+300,300,pass
+500,500,pass
+700,not-complete,insufficient-cpu

--- a/scripts/check_test_host_prereqs.sh
+++ b/scripts/check_test_host_prereqs.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+missing=()
+for tool in kind kubectl docker; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    missing+=("$tool")
+  fi
+done
+
+if (( ${#missing[@]} > 0 )); then
+  echo "error: missing required host tools for local scale evidence: ${missing[*]}" >&2
+  echo "install them, then rerun: make run-kind-scale-evidence" >&2
+  exit 1
+fi
+
+echo "host prereqs OK: kind kubectl docker are available"

--- a/scripts/collect_kind_scale_latency.sh
+++ b/scripts/collect_kind_scale_latency.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-scale-test}"
+OUT_DIR="${OUT_DIR:-$PWD/results/go-live/evidence/kind-scale-latency}"
+WINDOW_SECONDS="${WINDOW_SECONDS:-30}"
+
+mkdir -p "$OUT_DIR"
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "error: kubectl is required" >&2
+  exit 1
+fi
+
+if ! kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
+  echo "error: namespace $NAMESPACE does not exist" >&2
+  exit 1
+fi
+
+start_ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+printf '# Kind scale latency capture\n' > "$OUT_DIR/latency_capture.md"
+printf '\n- start: %s\n' "$start_ts" >> "$OUT_DIR/latency_capture.md"
+printf '- namespace: %s\n' "$NAMESPACE" >> "$OUT_DIR/latency_capture.md"
+printf '- window_seconds: %s\n' "$WINDOW_SECONDS" >> "$OUT_DIR/latency_capture.md"
+printf '\n## Snapshot\n\n' >> "$OUT_DIR/latency_capture.md"
+
+kubectl -n "$NAMESPACE" get pods -o wide >> "$OUT_DIR/latency_capture.md"
+
+printf '\n## Metrics sample\n\n' >> "$OUT_DIR/latency_capture.md"
+
+for pod in $(kubectl -n "$NAMESPACE" get pods -o jsonpath='{.items[*].metadata.name}'); do
+  echo "[latency] sampling $pod"
+  kubectl -n "$NAMESPACE" logs "$pod" --tail=200 >> "$OUT_DIR/${pod}.log" || true
+  kubectl -n "$NAMESPACE" exec "$pod" -- sh -c 'echo "${HOSTNAME} $(date -u +%Y-%m-%dT%H:%M:%SZ)"' >> "$OUT_DIR/pod_timestamps.txt" || true
+done
+
+printf '\n## Notes\n\n' >> "$OUT_DIR/latency_capture.md"
+printf 'This capture is a lightweight local latency signal for the kind scale harness. For stronger evidence, run with longer windows and compare the timings across the matrix.\n' >> "$OUT_DIR/latency_capture.md"
+
+echo "[latency] captured output to $OUT_DIR"

--- a/scripts/install_kind_prereqs_ubuntu.sh
+++ b/scripts/install_kind_prereqs_ubuntu.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INSTALL_DIR="${HOME}/.local/bin"
+mkdir -p "$INSTALL_DIR"
+export PATH="$INSTALL_DIR:$PATH"
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "[install] installing curl"
+  if command -v apt-get >/dev/null 2>&1; then
+    if [[ "$EUID" -eq 0 ]]; then
+      apt-get update
+      apt-get install -y curl ca-certificates
+    else
+      echo "error: this environment cannot install curl without root or sudo access" >&2
+      exit 1
+    fi
+  else
+    echo "error: curl is required and no apt-get is available" >&2
+    exit 1
+  fi
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[install] docker is required but not available in this restricted environment"
+  echo "install docker manually or run this on a Docker-capable host"
+  exit 1
+fi
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "[install] installing kubectl locally"
+  curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+  install -m 0755 /tmp/kubectl "$INSTALL_DIR/kubectl"
+fi
+
+if ! command -v kind >/dev/null 2>&1; then
+  echo "[install] installing kind locally"
+  curl -fsSL -o /tmp/kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
+  install -m 0755 /tmp/kind "$INSTALL_DIR/kind"
+fi
+
+echo "[install] prerequisites ready: docker kubectl kind"
+echo "[install] ensure this is in PATH: $INSTALL_DIR"

--- a/scripts/run_kind_scale_evidence.sh
+++ b/scripts/run_kind_scale_evidence.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+REPLICAS_LIST="${REPLICAS_LIST:-100,300,500}"
+NAMESPACE="${NAMESPACE:-scale-test}"
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/results/go-live/evidence}"
+WINDOW_SECONDS="${WINDOW_SECONDS:-30}"
+
+export REPLICAS_LIST NAMESPACE OUT_DIR WINDOW_SECONDS
+
+bash "$ROOT_DIR/scripts/run_kind_scale_matrix.sh"
+bash "$ROOT_DIR/scripts/collect_kind_scale_latency.sh"
+
+echo "[scale-evidence] completed. Outputs under $ROOT_DIR/results/go-live/evidence"

--- a/scripts/run_kind_scale_matrix.sh
+++ b/scripts/run_kind_scale_matrix.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPLICAS_LIST="${REPLICAS_LIST:-100,300,500}"
+CLUSTER_NAME="${CLUSTER_NAME:-sovereign-mohawk-scale-test}"
+NAMESPACE="${NAMESPACE:-scale-test}"
+CERT_DIR="${CERT_DIR:-${TMPDIR:-/tmp}/mohawk-scale-test-certs}"
+KIND_CONFIG_TEMPLATE="${ROOT_DIR}/deploy/kubernetes/scale-test/kind-config.yaml"
+KIND_CONFIG="${ROOT_DIR}/.tmp/kind-scale-matrix-config.yaml"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd kind
+require_cmd kubectl
+require_cmd docker
+
+parse_list() {
+  local raw="$1"
+  local IFS=','
+  for item in $raw; do
+    item="${item//[[:space:]]/}"
+    if [[ -n "$item" ]]; then
+      echo "$item"
+    fi
+  done
+}
+
+ensure_cluster() {
+  mkdir -p "$CERT_DIR"
+  mkdir -p "$(dirname "$KIND_CONFIG")"
+  cp "$KIND_CONFIG_TEMPLATE" "$KIND_CONFIG"
+  perl -0pi -e "s#/REPLACE/WITH/ABSOLUTE/PATH/TO/cert-pool-output/node-agent-certs#$CERT_DIR/node-agent-certs#g" "$KIND_CONFIG"
+
+  if kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
+    echo "[matrix] reusing kind cluster: $CLUSTER_NAME"
+    return
+  fi
+
+  echo "[matrix] creating kind cluster: $CLUSTER_NAME"
+  kind create cluster --name "$CLUSTER_NAME" --config "$KIND_CONFIG"
+}
+
+ensure_cert_pool() {
+  local max_replicas="$1"
+  local last_cert="$CERT_DIR/node-agent-certs/mohawk_tpm_client_$((max_replicas - 1))_cert.pem"
+  mkdir -p "$CERT_DIR"
+  if [[ ! -s "$last_cert" ]]; then
+    echo "[matrix] generating certificate pool for max replicas: $max_replicas"
+    MOHAWK_TPM_CLIENT_CERT_POOL_SIZE="$max_replicas" OUT_DIR="$CERT_DIR" bash "$ROOT_DIR/deploy/kubernetes/scale-test/generate-cert-pool.sh"
+  fi
+}
+
+ensure_images() {
+  if ! docker image inspect local/node-agent:scale-test >/dev/null 2>&1; then
+    echo "[matrix] building local/node-agent:scale-test"
+    docker build -f "$ROOT_DIR/cmd/node-agent/Dockerfile" -t local/node-agent:scale-test "$ROOT_DIR"
+  fi
+
+  if ! docker image inspect local/orchestrator:scale-test >/dev/null 2>&1; then
+    echo "[matrix] building local/orchestrator:scale-test"
+    docker build -f "$ROOT_DIR/cmd/orchestrator/Dockerfile" -t local/orchestrator:scale-test "$ROOT_DIR"
+  fi
+
+  kind load docker-image local/node-agent:scale-test --name "$CLUSTER_NAME"
+  kind load docker-image local/orchestrator:scale-test --name "$CLUSTER_NAME"
+
+  CONTROL_PLANE="${CLUSTER_NAME}-control-plane"
+  if ! docker exec "$CONTROL_PLANE" crictl image inspect ipfs/kubo:v0.28.0 >/dev/null 2>&1; then
+    echo "[matrix] pulling ipfs image into kind node"
+    docker exec "$CONTROL_PLANE" crictl pull ipfs/kubo:v0.28.0
+  fi
+}
+
+ensure_deployment() {
+  kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+  kubectl -n "$NAMESPACE" create secret generic mohawk-shared-secrets \
+    --from-file=mohawk_api_token="$CERT_DIR/mohawk_api_token" \
+    --from-file=mohawk_tpm_ca_cert.pem="$CERT_DIR/mohawk_tpm_ca_cert.pem" \
+    --from-file=mohawk_tpm_orchestrator_cert.pem="$CERT_DIR/mohawk_tpm_orchestrator_cert.pem" \
+    --from-file=mohawk_tpm_orchestrator_key.pem="$CERT_DIR/mohawk_tpm_orchestrator_key.pem" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+  kubectl apply -f "$ROOT_DIR/deploy/kubernetes/scale-test/01-orchestrator.yaml"
+  kubectl apply -f "$ROOT_DIR/deploy/kubernetes/scale-test/02-ipfs.yaml"
+  kubectl -n "$NAMESPACE" wait --for=condition=Ready pod -l app=orchestrator --timeout=180s
+  kubectl -n "$NAMESPACE" wait --for=condition=Ready pod -l app=ipfs --timeout=180s
+
+  kubectl apply -f "$ROOT_DIR/deploy/kubernetes/scale-test/03-node-agent.yaml"
+}
+
+collect_result() {
+  local replicas="$1"
+  echo "[matrix] running scale check at ${replicas} replicas"
+  kubectl -n "$NAMESPACE" scale statefulset node-agent --replicas="$replicas"
+  kubectl -n "$NAMESPACE" rollout status statefulset/node-agent --timeout=600s
+  READY_REPLICAS="$(kubectl -n "$NAMESPACE" get statefulset node-agent -o jsonpath='{.status.readyReplicas}')"
+  if [[ "$READY_REPLICAS" != "$replicas" ]]; then
+    echo "error: expected $replicas ready replicas, got $READY_REPLICAS" >&2
+    return 1
+  fi
+
+  local out="$ROOT_DIR/results/go-live/evidence/kind-scale-matrix"
+  mkdir -p "$out"
+  kubectl -n "$NAMESPACE" get pods -o wide > "$out/pods_${replicas}.txt"
+  kubectl -n "$NAMESPACE" get statefulset node-agent -o yaml > "$out/statefulset_${replicas}.yaml"
+  printf '%s,%s\n' "$replicas" "$READY_REPLICAS" >> "$out/summary.csv"
+  echo "[matrix] ${replicas} replicas ready"
+}
+
+max_replicas=0
+while IFS= read -r count; do
+  if [[ -n "$count" ]]; then
+    if (( count > max_replicas )); then
+      max_replicas="$count"
+    fi
+  fi
+done < <(parse_list "$REPLICAS_LIST")
+
+ensure_cert_pool "$max_replicas"
+ensure_cluster
+ensure_images
+ensure_deployment
+
+mkdir -p "$ROOT_DIR/results/go-live/evidence/kind-scale-matrix"
+: > "$ROOT_DIR/results/go-live/evidence/kind-scale-matrix/summary.csv"
+
+while IFS= read -r count; do
+  [[ -n "$count" ]] || continue
+  collect_result "$count"
+done < <(parse_list "$REPLICAS_LIST")
+
+echo "[matrix] complete. Summary in $ROOT_DIR/results/go-live/evidence/kind-scale-matrix/"

--- a/scripts/run_kind_scale_test.sh
+++ b/scripts/run_kind_scale_test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPLICAS="${REPLICAS:-500}"
+CLUSTER_NAME="${CLUSTER_NAME:-sovereign-mohawk-scale-test}"
+NAMESPACE="${NAMESPACE:-scale-test}"
+CERT_DIR="${CERT_DIR:-${TMPDIR:-/tmp}/mohawk-scale-test-certs}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+KIND_CONFIG_TEMPLATE="${ROOT_DIR}/deploy/kubernetes/scale-test/kind-config.yaml"
+GEN_CERT_SCRIPT="${ROOT_DIR}/deploy/kubernetes/scale-test/generate-cert-pool.sh"
+KIND_CONFIG="${ROOT_DIR}/.tmp/kind-scale-test-config.yaml"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd kind
+require_cmd kubectl
+require_cmd docker
+
+mkdir -p "$CERT_DIR"
+mkdir -p "$(dirname "$KIND_CONFIG")"
+cp "$KIND_CONFIG_TEMPLATE" "$KIND_CONFIG"
+perl -0pi -e "s#/REPLACE/WITH/ABSOLUTE/PATH/TO/cert-pool-output/node-agent-certs#$CERT_DIR/node-agent-certs#g" "$KIND_CONFIG"
+
+LAST_CERT="$CERT_DIR/node-agent-certs/mohawk_tpm_client_$((REPLICAS - 1))_cert.pem"
+if [[ ! -s "$LAST_CERT" ]]; then
+  echo "[scale-test] generating certificate pool for $REPLICAS replicas"
+  MOHAWK_TPM_CLIENT_CERT_POOL_SIZE="$REPLICAS" OUT_DIR="$CERT_DIR" bash "$GEN_CERT_SCRIPT"
+fi
+
+if ! kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
+  echo "[scale-test] creating kind cluster: $CLUSTER_NAME"
+  kind create cluster --name "$CLUSTER_NAME" --config "$KIND_CONFIG"
+else
+  echo "[scale-test] reusing kind cluster: $CLUSTER_NAME"
+fi
+
+if ! docker image inspect local/node-agent:scale-test >/dev/null 2>&1; then
+  echo "[scale-test] building node-agent image"
+  docker build -f "$ROOT_DIR/cmd/node-agent/Dockerfile" -t local/node-agent:scale-test "$ROOT_DIR"
+fi
+
+if ! docker image inspect local/orchestrator:scale-test >/dev/null 2>&1; then
+  echo "[scale-test] building orchestrator image"
+  docker build -f "$ROOT_DIR/cmd/orchestrator/Dockerfile" -t local/orchestrator:scale-test "$ROOT_DIR"
+fi
+
+kind load docker-image local/node-agent:scale-test --name "$CLUSTER_NAME"
+kind load docker-image local/orchestrator:scale-test --name "$CLUSTER_NAME"
+
+CONTROL_PLANE="${CLUSTER_NAME}-control-plane"
+if ! docker exec "$CONTROL_PLANE" crictl image inspect ipfs/kubo:v0.28.0 >/dev/null 2>&1; then
+  echo "[scale-test] pulling ipfs image into kind node"
+  docker exec "$CONTROL_PLANE" crictl pull ipfs/kubo:v0.28.0
+fi
+
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n "$NAMESPACE" create secret generic mohawk-shared-secrets \
+  --from-file=mohawk_api_token="$CERT_DIR/mohawk_api_token" \
+  --from-file=mohawk_tpm_ca_cert.pem="$CERT_DIR/mohawk_tpm_ca_cert.pem" \
+  --from-file=mohawk_tpm_orchestrator_cert.pem="$CERT_DIR/mohawk_tpm_orchestrator_cert.pem" \
+  --from-file=mohawk_tpm_orchestrator_key.pem="$CERT_DIR/mohawk_tpm_orchestrator_key.pem" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl apply -f "$ROOT_DIR/deploy/kubernetes/scale-test/01-orchestrator.yaml"
+kubectl apply -f "$ROOT_DIR/deploy/kubernetes/scale-test/02-ipfs.yaml"
+
+kubectl -n "$NAMESPACE" wait --for=condition=Ready pod -l app=orchestrator --timeout=180s
+kubectl -n "$NAMESPACE" wait --for=condition=Ready pod -l app=ipfs --timeout=180s
+
+kubectl apply -f "$ROOT_DIR/deploy/kubernetes/scale-test/03-node-agent.yaml"
+
+kubectl -n "$NAMESPACE" scale statefulset node-agent --replicas="$REPLICAS"
+kubectl -n "$NAMESPACE" rollout status statefulset/node-agent --timeout=600s
+
+READY_REPLICAS="$(kubectl -n "$NAMESPACE" get statefulset node-agent -o jsonpath='{.status.readyReplicas}')"
+if [[ "$READY_REPLICAS" != "$REPLICAS" ]]; then
+  echo "error: expected $REPLICAS ready replicas, got $READY_REPLICAS" >&2
+  exit 1
+fi
+
+echo "[scale-test] success: $READY_REPLICAS/$REPLICAS node-agent replicas are ready"
+echo "[scale-test] namespace: $NAMESPACE"
+echo "[scale-test] cert dir: $CERT_DIR"
+echo "[scale-test] next commands:"
+echo "  kubectl -n $NAMESPACE get pods"
+echo "  docker exec $CONTROL_PLANE crictl stats"


### PR DESCRIPTION
## Summary
- add local kind scale automation targets and scripts for single-run, matrix, and evidence capture workflows
- add host prerequisite check and Ubuntu/Debian local installer for kind/kubectl in restricted environments
- add multi-host readiness guidance for scaling beyond single-host kind ceilings
- include compact evidence artifacts showing successful readiness at 100/300/500 and the 700-replica CPU scheduling boundary

## Evidence
- successful readiness tiers recorded in results/go-live/evidence/kind-scale-matrix/summary.csv
- run analysis and boundary notes recorded in results/go-live/evidence/kind-scale-matrix/scale-evidence-2026-08-16.md

## Validation
- source scripts/ensure_go_toolchain.sh && make lint
- source scripts/ensure_go_toolchain.sh && make test
- source scripts/ensure_go_toolchain.sh && make local-validation-scripts
- bash -n scripts/run_kind_scale_test.sh scripts/run_kind_scale_matrix.sh

## Notes
- large raw runtime artifacts under results/** remain gitignored; this PR includes only compact summary evidence.